### PR TITLE
tests for meta, fixes version bug, guards for ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lectern",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Data Dictionary Management",
   "scripts": {
     "start": "npm run serve",

--- a/src/config/MetaSchema.json
+++ b/src/config/MetaSchema.json
@@ -4,18 +4,15 @@
     "definitions": {
         "stringMeta": {
             "type": "object",
-            "properties": {
-                "key": {
-                    "type": "boolean",
-                    "enum": [
-                        true
-                    ]
-                },
-                "default": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
+            "properties": {},
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                ]
+            }
         },
         "stringRestrictions": {
             "type": "object",
@@ -42,18 +39,15 @@
         },
         "integerMeta": {
             "type": "object",
-            "properties": {
-                "key": {
-                    "type": "boolean",
-                    "enum": [
-                        true
-                    ]
-                },
-                "default": {
-                    "type": "integer"
-                }
-            },
-            "additionalProperties": false
+            "properties": {},
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                ]
+            }
         },
         "integerRestrictions": {
             "type": "object",
@@ -77,13 +71,15 @@
         },
         "numberMeta": {
             "type": "object",
-            "properties": {
-                "default": {
-                    "type": "number"
-                }
-            },
-            "maxProperties": 1,
-            "additionalProperties": false
+            "properties": {},
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                ]
+            }
         },
         "numberRestrictions": {
             "type": "object",
@@ -107,13 +103,15 @@
         },
         "booleanMeta": {
             "type": "object",
-            "properties": {
-                "default": {
-                    "type": "boolean"
-                }
-            },
-            "maxProperties": 1,
-            "additionalProperties": false
+            "properties": {},
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                ]
+            }
         },
         "booleanRestrictions": {
             "type": "object",
@@ -136,9 +134,6 @@
             ],
             "properties": {
                 "name": {
-                    "type": "string"
-                },
-                "displayName": {
                     "type": "string"
                 },
                 "description": {

--- a/src/controllers/dictionaryController.ts
+++ b/src/controllers/dictionaryController.ts
@@ -33,6 +33,7 @@ export const addSchema = async (req: Request, res: Response) => {
 };
 
 export const updateSchema = async (req: Request, res: Response) => {
+    if (req.params.dictId === undefined) throw new BadRequestError("Must specify valid dictId");
     const dict = await dictionaryService.updateSchema(req.params.dictId, req.body, req.query.major == true);
     res.status(200).send(dict.toObject());
 };

--- a/src/services/dictionaryService.ts
+++ b/src/services/dictionaryService.ts
@@ -9,7 +9,7 @@ import { incrementMajor, incrementMinor, isValidVersion, isGreater } from "../ut
  * @param version Version of the dictionary
  */
 export const findOne = async (name: string, version: string): Promise<DictionaryDocument> => {
-    const dict = await Dictionary.findOne({"name": name, "version": version});
+    const dict = await Dictionary.findOne({ "name": name, "version": version });
     return dict;
 };
 
@@ -18,7 +18,7 @@ export const findOne = async (name: string, version: string): Promise<Dictionary
  * @param id id of the Dictionary
  */
 export const getOne = async (id: string): Promise<DictionaryDocument> => {
-    const dict = await Dictionary.findOne({"_id": id });
+    const dict = await Dictionary.findOne({ "_id": id });
     if (dict == undefined) {
         throw new NotFoundError("Cannot find dictionary with id " + id);
     }
@@ -38,7 +38,7 @@ export const listAll = async (): Promise<DictionaryDocument[]> => {
  * and that the schemas are valid against the meta schema.
  * @param newDict The new data dictionary containing all of the schemas
  */
-export const create = async (newDict: {name: string, version: string, schemas: any[]}): Promise<DictionaryDocument> => {
+export const create = async (newDict: { name: string, version: string, schemas: any[] }): Promise<DictionaryDocument> => {
     // Verify version is correct format
     if (!isValidVersion(newDict.version)) {
         throw new BadRequestError("Invalid version format");
@@ -119,12 +119,16 @@ export const updateSchema = async (id: string, schema: any, major: boolean): Pro
         "_id": id
     }).exec();
 
+    if (doc === undefined) {
+        throw new NotFoundError("Cannot update dictionary that does not exist.");
+    }
+
     // Ensure it exists
     const entities = doc.schemas.map(s => s["name"]);
     if (!entities.includes(schema["name"])) throw new BadRequestError("Cannot update schema that does not exist.");
 
     // Filter out one to update
-    const schemas = doc.schemas.filter( s => !(s["name"] === schema["name"]));
+    const schemas = doc.schemas.filter(s => !(s["name"] === schema["name"]));
     schemas.push(schema);
 
     // Increment Version
@@ -142,10 +146,10 @@ export const updateSchema = async (id: string, schema: any, major: boolean): Pro
 };
 
 export const getLatestVersion = async (name: string): Promise<string> => {
-    const dicts = await Dictionary.find({"name": name});
+    const dicts = await Dictionary.find({ "name": name });
     let latest = "0.0";
     if (dicts != undefined) {
-        dicts.forEach( dict => {
+        dicts.forEach(dict => {
             if (isGreater(dict.version, latest)) {
                 latest = dict.version;
             }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -74,6 +74,9 @@ export const errorHandler = (err: Error, req: Request, res: Response, next: Next
         case "MalformedVersion":
             res.status(400);
             break;
+        case "CastError":
+            res.status(400);
+            break;
         default:
             res.status(500);
             break;

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -13,7 +13,7 @@ export const incrementMinor = (version: string): string => {
 export const incrementMajor = (version: string): string => {
     if (!isValidVersion(version)) throw new MalformedVersionError("Version string is malformed: " + version);
     const parts = version.split(".");
-    return (parseInt(parts[0]) + 1).toString() + "." + parts[1];
+    return (parseInt(parts[0]) + 1).toString() + "." + "0";
 };
 
 export const isGreater = (v1: string, v2: string): boolean => {

--- a/test/functional/versionTests.ts
+++ b/test/functional/versionTests.ts
@@ -36,11 +36,11 @@ describe("Incrementing version strings", () => {
     });
 
     it("Should increment major version", () => {
-        expect(incrementMajor("1.9")).to.equal("2.9");
+        expect(incrementMajor("1.9")).to.equal("2.0");
     });
 
     it("Should increment major version with increase in digits", () => {
-        expect(incrementMajor("9.9")).to.equal("10.9");
+        expect(incrementMajor("9.9")).to.equal("10.0");
     });
 
 });

--- a/test/integration/crudIntegrationTests.ts
+++ b/test/integration/crudIntegrationTests.ts
@@ -61,6 +61,30 @@ describe("Basic CRUD", () => {
                 setImmediate(done);
             });
         });
+
+        it("Should create a new dictionary with lots of Key/Value meta fields", (done: Mocha.Done) => {
+            chai.request(app)
+                .post("/dictionaries")
+                .send(require("./fixtures/createKeyValue.json"))
+                .end((err: Error, res: Response) => {
+                    expect(err).to.be.null;
+                    expect(res).to.have.status(200);
+                    setImmediate(done);
+                });
+        });
+
+        it("Should 400 with meta fields that are not string/boolean/integer/number", (done: Mocha.Done) => {
+            const dictRequest = require("./fixtures/createKeyValueBad.json");
+            chai.request(app)
+            .post("/dictionaries")
+            .send(dictRequest)
+            .end((err: Error, res: Response) => {
+                expect(err).to.be.null;
+                expect(res).to.have.status(400);
+                setImmediate(done);
+            });
+        });
+
     });
 
     describe("Read", () => {
@@ -88,6 +112,16 @@ describe("Basic CRUD", () => {
                     expect(err).to.be.null;
                     expect(res).to.have.status(200);
                     expect(res.body.version).to.equal(testVersion);
+                    setImmediate(done);
+                });
+        });
+
+        it("Should 400 with a badly formed dictionary id", (done: Mocha.Done) => {
+            chai.request(app)
+                .get("/dictionaries/aslkjfdabhskjlfhsdalkjfhsadfklsja")
+                .end((err: Error, res: Response) => {
+                    expect(err).to.be.null;
+                    expect(res).to.have.status(400);
                     setImmediate(done);
                 });
         });
@@ -133,7 +167,7 @@ describe("Basic CRUD", () => {
                 .end((err: Error, res: Response) => {
                     expect(err).to.be.null;
                     expect(res).to.have.status(200);
-                    expect(res.body.version).to.equal("11.10");
+                    expect(res.body.version).to.equal("11.0");
                     nextId = res.body._id;
                     setImmediate(done);
                 });
@@ -147,11 +181,22 @@ describe("Basic CRUD", () => {
                 .end((err: Error, res: Response) => {
                     expect(err).to.be.null;
                     expect(res).to.have.status(200);
-                    expect(res.body.version).to.equal("11.11");
+                    expect(res.body.version).to.equal("11.1");
                     setImmediate(done);
                 });
         });
 
+        it("Should respond with bad request on poorly formatted dicitonary_id", (done: Mocha.Done) => {
+            const newFile = require("./fixtures/updateNewFile.json");
+            chai.request(app)
+                .put(`/dictionaries/kljadsbflsdafsdakljsdfkp/schemas`)
+                .send(newFile)
+                .end((err: Error, res: Response) => {
+                    expect(err).to.be.null;
+                    expect(res).to.have.status(400);
+                    setImmediate(done);
+                });
+        });
     });
 
     describe("Delete", () => {

--- a/test/integration/fixtures/createKeyValue.json
+++ b/test/integration/fixtures/createKeyValue.json
@@ -1,0 +1,158 @@
+{
+    "name": "Key Value Meta",
+    "version": "1.0",
+    "schemas": [
+        {
+            "name": "key_value_test",
+            "description": "key_value_test",
+            "key": "kv_id",
+            "fields": [
+                {
+                    "name": "kv_id",
+                    "valueType": "string",
+                    "description": "kv_id",
+                    "meta": {
+                        "key": true,
+                        "displayName": "KEY VALUE ID"
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^[A-Z1-9][-_A-Z1-9]{2,7}(-[A-Z][A-Z])$"
+                    }
+                },
+                {
+                    "name": "foo",
+                    "valueType": "string",
+                    "description": "foo",
+                    "meta": {
+                        "displayName": "FOOOOO",
+                        "default": "blabla"
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(DO|do)).+"
+                    }
+                },
+                {
+                    "name": "bar",
+                    "valueType": "string",
+                    "description": "The gender of the patient",
+                    "meta": {
+                        "funny": false,
+                        "test": true,
+                        "adkadfaskljd": 2109312983
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "foo",
+                            "bar",
+                            "biz"
+                        ]
+                    }
+                },
+                {
+                    "name": "baz",
+                    "valueType": "string",
+                    "description": "baz",
+                    "meta": {
+                        "displayName": "wololo",
+                        "key": true,
+                        "double": 0.12
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(SP|sp)).+"
+                    }
+                },
+                {
+                    "name": "specimen_type",
+                    "valueType": "string",
+                    "description": "Indicate the tissue source of the biospecimen",
+                    "meta": {
+                        "displayName": "Specimen Typo",
+                        "units": "mg",
+                        "tags" : "blabla",
+                        "default": "Other"
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Blood derived",
+                            "Blood derived - bone marrow",
+                            "Blood derived - peripheral blood",
+                            "Bone marrow",
+                            "Buccal cell",
+                            "Lymph node",
+                            "Solid tissue",
+                            "Plasma",
+                            "Serum",
+                            "Urine",
+                            "Cerebrospinal fluid",
+                            "Sputum",
+                            "NOS (Not otherwise specified)",
+                            "Other",
+                            "FFPE",
+                            "Pleural effusion",
+                            "Mononuclear cells from bone marrow",
+                            "Saliva",
+                            "Skin"
+                        ]
+                    }
+                },
+                {
+                    "name": "tumour_normal_designation",
+                    "valueType": "string",
+                    "description": "Indicate whether specimen is tumour or normal type",
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Normal",
+                            "Normal - tissue adjacent to primary tumour",
+                            "Primary tumour",
+                            "Primary tumour - adjacent to normal",
+                            "Primary tumour - additional new primary",
+                            "Recurrent tumour",
+                            "Metastatic tumour",
+                            "Metastatic tumour - metastasis local to lymph node",
+                            "Metastatic tumour - metastasis to distant location",
+                            "Metastatic tumour - additional metastatic",
+                            "Xenograft - derived from primary tumour",
+                            "Xenograft - derived from tumour cell line",
+                            "Cell line - derived from xenograft tissue",
+                            "Cell line - derived from tumour",
+                            "Cell line - derived from normal"
+                        ]
+                    }
+                },
+                {
+                    "name": "sample_submitter_id",
+                    "valueType": "string",
+                    "description": "Submitter assigned sample id",
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(SA|sa)).+"
+                    }
+                },
+                {
+                    "name": "sample_type",
+                    "valueType": "string",
+                    "description": "Specimen Type",
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Total DNA",
+                            "Amplified DNA",
+                            "ctDNA",
+                            "other DNA enrichments",
+                            "Total RNA",
+                            "Ribo-Zero RNA",
+                            "polyA+ RNA",
+                            "other RNA fractions"
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/test/integration/fixtures/createKeyValueBad.json
+++ b/test/integration/fixtures/createKeyValueBad.json
@@ -1,0 +1,159 @@
+{
+    "name": "Key Value Meta",
+    "version": "1.1",
+    "schemas": [
+        {
+            "name": "key_value_test",
+            "description": "key_value_test",
+            "key": "kv_id",
+            "fields": [
+                {
+                    "name": "kv_id",
+                    "valueType": "string",
+                    "description": "kv_id",
+                    "meta": {
+                        "key": true,
+                        "displayName": "KEY VALUE ID",
+                        "noArrays": ["lol", "sorry", "no_arrays", "please"]
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^[A-Z1-9][-_A-Z1-9]{2,7}(-[A-Z][A-Z])$"
+                    }
+                },
+                {
+                    "name": "foo",
+                    "valueType": "string",
+                    "description": "foo",
+                    "meta": {
+                        "displayName": "FOOOOO",
+                        "default": "blabla"
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(DO|do)).+"
+                    }
+                },
+                {
+                    "name": "bar",
+                    "valueType": "string",
+                    "description": "The gender of the patient",
+                    "meta": {
+                        "funny": false,
+                        "test": true,
+                        "adkadfaskljd": 2109312983
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "foo",
+                            "bar",
+                            "biz"
+                        ]
+                    }
+                },
+                {
+                    "name": "baz",
+                    "valueType": "string",
+                    "description": "baz",
+                    "meta": {
+                        "displayName": "wololo",
+                        "key": true,
+                        "double": 0.12
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(SP|sp)).+"
+                    }
+                },
+                {
+                    "name": "specimen_type",
+                    "valueType": "string",
+                    "description": "Indicate the tissue source of the biospecimen",
+                    "meta": {
+                        "displayName": "Specimen Typo",
+                        "units": "mg",
+                        "tags" : "blabla",
+                        "default": "Other"
+                    },
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Blood derived",
+                            "Blood derived - bone marrow",
+                            "Blood derived - peripheral blood",
+                            "Bone marrow",
+                            "Buccal cell",
+                            "Lymph node",
+                            "Solid tissue",
+                            "Plasma",
+                            "Serum",
+                            "Urine",
+                            "Cerebrospinal fluid",
+                            "Sputum",
+                            "NOS (Not otherwise specified)",
+                            "Other",
+                            "FFPE",
+                            "Pleural effusion",
+                            "Mononuclear cells from bone marrow",
+                            "Saliva",
+                            "Skin"
+                        ]
+                    }
+                },
+                {
+                    "name": "tumour_normal_designation",
+                    "valueType": "string",
+                    "description": "Indicate whether specimen is tumour or normal type",
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Normal",
+                            "Normal - tissue adjacent to primary tumour",
+                            "Primary tumour",
+                            "Primary tumour - adjacent to normal",
+                            "Primary tumour - additional new primary",
+                            "Recurrent tumour",
+                            "Metastatic tumour",
+                            "Metastatic tumour - metastasis local to lymph node",
+                            "Metastatic tumour - metastasis to distant location",
+                            "Metastatic tumour - additional metastatic",
+                            "Xenograft - derived from primary tumour",
+                            "Xenograft - derived from tumour cell line",
+                            "Cell line - derived from xenograft tissue",
+                            "Cell line - derived from tumour",
+                            "Cell line - derived from normal"
+                        ]
+                    }
+                },
+                {
+                    "name": "sample_submitter_id",
+                    "valueType": "string",
+                    "description": "Submitter assigned sample id",
+                    "restrictions": {
+                        "required": true,
+                        "regex": "^(?!(SA|sa)).+"
+                    }
+                },
+                {
+                    "name": "sample_type",
+                    "valueType": "string",
+                    "description": "Specimen Type",
+                    "restrictions": {
+                        "required": true,
+                        "codeList": [
+                            "Total DNA",
+                            "Amplified DNA",
+                            "ctDNA",
+                            "other DNA enrichments",
+                            "Total RNA",
+                            "Ribo-Zero RNA",
+                            "polyA+ RNA",
+                            "other RNA fractions"
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Updated lectern version from 1.0.0 -> 1.1.0

### New Features
- Key/Value for Meta portion of a field. Only allows boolean, string, number, integer values. 
  - includes tests for good and bad values. 

### Enhancements
- Guard on id definition
- Handling mongo CastError on bad input

### Bug Fixes
- version was not correctly being incremented in the major version number case. 
