### PR TITLE
Add References System to Dictionary

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ const App = (config: AppConfig): Express => {
   /**
    * Auth Decorator
    */
-  const egoDecorator = process.env.AUTH_ENABLED == 'true' ? ego() : wrapAsync;
+  const egoDecorator = process.env.AUTH_ENABLED === 'true' ? ego() : wrapAsync;
 
   // Create Express server with mongoConfig
   const app = express();

--- a/src/config/MetaSchema.json
+++ b/src/config/MetaSchema.json
@@ -26,12 +26,17 @@
       "type": "object",
       "properties": {
         "codeList": {
-          "type": "array",
-          "minItems": 2,
-          "uniqueItems": true,
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            { "type": "string", "pattern": "^#(\\/[-_A-Za-z0-9]+)+$" }
+          ]
         },
         "required": {
           "type": "boolean"

--- a/src/config/MetaSchema.json
+++ b/src/config/MetaSchema.json
@@ -84,9 +84,6 @@
             "type": "integer"
           }
         },
-        "script": {
-          "type": "string"
-        },
         "range": {
           "type": "object",
           "oneOf": [
@@ -212,9 +209,6 @@
             "type": "number"
           }
         },
-        "script": {
-          "type": "string"
-        },
         "range": {
           "type": "object",
           "oneOf": [
@@ -332,9 +326,6 @@
       "properties": {
         "required": {
           "type": "boolean"
-        },
-        "script": {
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -27,7 +27,8 @@
             "schema": {
               "type": "string"
             }
-          }
+          },
+          { "$ref": "#/components/parameters/ShowReferences" }
         ],
         "responses": {
           "200": {
@@ -95,7 +96,8 @@
             "schema": {
               "type": "string"
             }
-          }
+          },
+          { "$ref": "#/components/parameters/ShowReferences" }
         ],
         "responses": {
           "200": {
@@ -220,7 +222,8 @@
             "schema": {
               "type": "string"
             }
-          }
+          },
+          { "$ref": "#/components/parameters/ShowReferences" }
         ],
         "responses": {
           "200": {
@@ -244,6 +247,18 @@
     }
   ],
   "components": {
+    "parameters": {
+      "ShowReferences": {
+        "name": "references",
+        "summary": "show references in schema response",
+        "description": "If true, the schema references will be left in the response. By default, all references are replaced with their referenced values.",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
     "requestBodies": {
       "FileSchema": {
         "content": {

--- a/src/controllers/dictionaryController.ts
+++ b/src/controllers/dictionaryController.ts
@@ -23,14 +23,14 @@ export const listDictionaries = async (req: Request, res: Response) => {
 };
 
 export const getDictionary = async (req: Request, res: Response) => {
-  const showReferences = (req.query.references = false);
+  const showReferences = req.query.references || false;
   const id = req.params.dictId;
 
   const dict = await dictionaryService.getOne(id);
   const response = showReferences
     ? dict.toObject()
     : dictionaryService.replaceReferences(dict.toObject());
-  res.status(200).send(dict);
+  res.status(200).send(response);
 };
 
 export const createDictionary = async (req: Request, res: Response) => {

--- a/src/controllers/dictionaryController.ts
+++ b/src/controllers/dictionaryController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import * as dictionaryService from '../services/dictionaryService';
 import { BadRequestError } from '../utils/errors';
+import { replaceReferences } from '../utils/references';
 import { diff as diffUtil } from '../diff/DictionaryDiff';
 import logger from '../config/logger';
 
@@ -11,9 +12,7 @@ export const listDictionaries = async (req: Request, res: Response) => {
 
   if (name && version) {
     const dict = await dictionaryService.findOne(name, version);
-    const response = showReferences
-      ? dict.toObject()
-      : dictionaryService.replaceReferences(dict.toObject());
+    const response = showReferences ? dict.toObject() : replaceReferences(dict.toObject());
     res.status(200).send([response]);
   } else {
     const dicts = await dictionaryService.listAll();
@@ -27,9 +26,7 @@ export const getDictionary = async (req: Request, res: Response) => {
   const id = req.params.dictId;
 
   const dict = await dictionaryService.getOne(id);
-  const response = showReferences
-    ? dict.toObject()
-    : dictionaryService.replaceReferences(dict.toObject());
+  const response = showReferences ? dict.toObject() : replaceReferences(dict.toObject());
   res.status(200).send(response);
 };
 
@@ -59,12 +56,8 @@ export const diffDictionaries = async (req: Request, res: Response) => {
   if (name && leftVersion && rightVersion) {
     const dict1Doc = await dictionaryService.findOne(name, leftVersion);
     const dict2Doc = await dictionaryService.findOne(name, rightVersion);
-    const dict1 = showReferences
-      ? dict1Doc.toObject()
-      : dictionaryService.replaceReferences(dict1Doc.toObject());
-    const dict2 = showReferences
-      ? dict2Doc.toObject()
-      : dictionaryService.replaceReferences(dict2Doc.toObject());
+    const dict1 = showReferences ? dict1Doc.toObject() : replaceReferences(dict1Doc.toObject());
+    const dict2 = showReferences ? dict2Doc.toObject() : replaceReferences(dict2Doc.toObject());
     const diff = diffUtil(dict1, dict2);
     res.status(200).send(Array.from(diff.entries()));
   } else {

--- a/src/models/Dictionary.ts
+++ b/src/models/Dictionary.ts
@@ -4,6 +4,7 @@ export type DictionaryDocument = mongoose.Document & {
   name: string;
   version: string;
   schemas: any[];
+  references: any;
 };
 
 const DictionarySchema = new mongoose.Schema(
@@ -11,6 +12,7 @@ const DictionarySchema = new mongoose.Schema(
     name: String,
     version: String,
     schemas: Array,
+    references: Object,
   },
   { timestamps: true },
 );

--- a/src/services/dictionaryService.ts
+++ b/src/services/dictionaryService.ts
@@ -1,7 +1,7 @@
 import { Dictionary, DictionaryDocument } from '../models/Dictionary';
 import {
   ConflictError,
-  InternalServerError,
+  InvalidReferenceError,
   BadRequestError,
   NotFoundError,
 } from '../utils/errors';
@@ -241,7 +241,7 @@ export const replaceSchemaReferences = (schema: any, references: any) => {
 
         // Ensure we found a value, otherwise throw error for invalid reference
         if (!replaceValue) {
-          throw new InternalServerError(
+          throw new InvalidReferenceError(
             `Unknown reference found - Schema: ${clone.name} Field: ${field.name} Reference: ${reference}`,
           );
         }

--- a/src/services/dictionaryService.ts
+++ b/src/services/dictionaryService.ts
@@ -101,13 +101,6 @@ export const create = async (newDict: {
     if (!result.valid) throw new BadRequestError(JSON.stringify(result.errors));
   });
 
-  // Verify that this dictionary version doesn't already exist.
-  const doc = await Dictionary.findOne({
-    name: newDict.name,
-    version: newDict.version,
-  }).exec();
-  if (doc) throw new ConflictError('This dictionary version already exists.');
-
   // Save new dictionary version
   const dict = new Dictionary({
     name: newDict.name,

--- a/src/services/dictionaryService.ts
+++ b/src/services/dictionaryService.ts
@@ -1,14 +1,8 @@
 import { Dictionary, DictionaryDocument } from '../models/Dictionary';
-import {
-  ConflictError,
-  InvalidReferenceError,
-  BadRequestError,
-  NotFoundError,
-} from '../utils/errors';
+import { ConflictError, BadRequestError, NotFoundError } from '../utils/errors';
 import { validate } from '../services/schemaService';
 import { incrementMajor, incrementMinor, isValidVersion, isGreater } from '../utils/version';
 import logger from '../config/logger';
-import { get, omit, cloneDeep } from 'lodash';
 
 const getLatestVersion = async (name: string): Promise<string> => {
   const dicts = await Dictionary.find({ name: name });
@@ -195,60 +189,4 @@ export const updateSchema = async (
 
   const saved = await dict.save();
   return saved;
-};
-
-/**
- *
- * @param dictionary Dictionary object, matching the mongoose documents
- * @returns Dictionary with replacements made
- */
-export const replaceReferences = (dictionary: DictionaryDocument) => {
-  const { schemas, references } = dictionary;
-
-  const updatedSchemas = schemas.map(schema => replaceSchemaReferences(schema, references));
-  const clone = cloneDeep(dictionary);
-  clone.schemas = updatedSchemas;
-  // Remove references property
-  return omit(clone, 'references');
-};
-
-/**
- * @param schema
- * @param references
- */
-export const replaceSchemaReferences = (schema: any, references: any) => {
-  const isReferenceValue = (value: string) => {
-    const regex = new RegExp('^#(/[-_A-Za-z0-9]+)+$');
-    return regex.test(value);
-  };
-
-  const referenceToObjectPath = (value: string) => {
-    return value
-      .split('/')
-      .slice(1)
-      .join('.');
-  };
-
-  const clone = cloneDeep(schema);
-  clone.fields.forEach((field: any) => {
-    for (const key in field.restrictions) {
-      const value = field.restrictions[key];
-
-      if (isReferenceValue(value)) {
-        const reference = referenceToObjectPath(value);
-
-        const replaceValue = get(references, reference, undefined);
-
-        // Ensure we found a value, otherwise throw error for invalid reference
-        if (!replaceValue) {
-          throw new InvalidReferenceError(
-            `Unknown reference found - Schema: ${clone.name} Field: ${field.name} Reference: ${reference}`,
-          );
-        }
-
-        field.restrictions[key] = replaceValue;
-      }
-    }
-  });
-  return clone;
 };

--- a/src/services/schemaService.ts
+++ b/src/services/schemaService.ts
@@ -1,11 +1,17 @@
 import MetaSchema from '../config/MetaSchema.json';
 import Ajv from 'ajv';
+import { replaceSchemaReferences } from './dictionaryService';
 
-export function validate(dictionary: any) {
+export function validate(schema: any, references: any) {
+  const schemaWithReplacements = replaceSchemaReferences(schema, references);
+
+  // Validate vs MetaSchema
   const ajv = new Ajv({
     allErrors: true,
     jsonPointers: true,
   });
   const validate = ajv.compile(MetaSchema);
-  return { valid: validate(dictionary), errors: validate.errors };
+  const metaSchemaValid = validate(schemaWithReplacements);
+
+  return { valid: validate(schemaWithReplacements), errors: validate.errors };
 }

--- a/src/services/schemaService.ts
+++ b/src/services/schemaService.ts
@@ -1,6 +1,6 @@
 import MetaSchema from '../config/MetaSchema.json';
 import Ajv from 'ajv';
-import { replaceSchemaReferences } from './dictionaryService';
+import { replaceSchemaReferences } from '../utils/references';
 
 export function validate(schema: any, references: any) {
   const schemaWithReplacements = replaceSchemaReferences(schema, references);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -50,6 +50,13 @@ export class ForbiddenError extends Error {
   }
 }
 
+export class InvalidReferenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidReference';
+  }
+}
+
 export const errorHandler = (err: Error, req: Request, res: Response, next: NextFunction): any => {
   if (res.headersSent) {
     return next(err);
@@ -75,6 +82,9 @@ export const errorHandler = (err: Error, req: Request, res: Response, next: Next
       res.status(400);
       break;
     case 'CastError':
+      res.status(400);
+      break;
+    case 'InvalidReference':
       res.status(400);
       break;
     default:

--- a/src/utils/references.ts
+++ b/src/utils/references.ts
@@ -1,0 +1,62 @@
+import { DictionaryDocument } from '../models/Dictionary';
+import { InvalidReferenceError } from '../utils/errors';
+import { get, omit, cloneDeep } from 'lodash';
+
+/**
+ *
+ * @param dictionary Dictionary object, matching the mongoose documents
+ * @returns Dictionary with replacements made
+ */
+export const replaceReferences = (dictionary: DictionaryDocument) => {
+  const { schemas, references } = dictionary;
+
+  const updatedSchemas = schemas.map(schema => replaceSchemaReferences(schema, references));
+  const clone = cloneDeep(dictionary);
+  clone.schemas = updatedSchemas;
+  // Remove references property
+  return omit(clone, 'references');
+};
+
+/**
+ * @param schema
+ * @param references
+ * @return schema clone with references replaced
+ */
+export const replaceSchemaReferences = (schema: any, references: any) => {
+  const isReferenceValue = (value: string) => {
+    const regex = new RegExp('^#(/[-_A-Za-z0-9]+)+$');
+    return regex.test(value);
+  };
+
+  const referenceToObjectPath = (value: string) => {
+    return value
+      .split('/')
+      .slice(1)
+      .join('.');
+  };
+
+  const clone = cloneDeep(schema);
+  clone.fields.forEach((field: any) => {
+    for (const key in field.restrictions) {
+      const value = field.restrictions[key];
+
+      if (isReferenceValue(value)) {
+        const reference = referenceToObjectPath(value);
+
+        const replaceValue = get(references, reference, undefined);
+
+        // Ensure we found a value, otherwise throw error for invalid reference
+        if (!replaceValue) {
+          throw new InvalidReferenceError(
+            `Unknown reference found - Schema: ${clone.name} Field: ${
+              field.name
+            } Reference: ${reference}`,
+          );
+        }
+
+        field.restrictions[key] = replaceValue;
+      }
+    }
+  });
+  return clone;
+};

--- a/test/integration/crudIntegrationTests.ts
+++ b/test/integration/crudIntegrationTests.ts
@@ -132,6 +132,45 @@ describe('CRUD', () => {
           setImmediate(done);
         });
     });
+
+    it('Should 400 with a codeList reference that is not properly formatted', (done: Mocha.Done) => {
+      const dictRequest = require('./fixtures/createKeyValueBadReferenceFormat.json');
+      chai
+        .request(app)
+        .post('/dictionaries')
+        .send(dictRequest)
+        .end((err: Error, res: Response) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(400);
+          setImmediate(done);
+        });
+    });
+
+    it('Should 400 with a reference that is unknown', (done: Mocha.Done) => {
+      const dictRequest = require('./fixtures/createKeyValueBadUnknownReference.json');
+      chai
+        .request(app)
+        .post('/dictionaries')
+        .send(dictRequest)
+        .end((err: Error, res: Response) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(400);
+          setImmediate(done);
+        });
+    });
+
+    it('Should 400 with a reference that provides an illegal value', (done: Mocha.Done) => {
+      const dictRequest = require('./fixtures/createKeyValueBadReferenceValueType.json');
+      chai
+        .request(app)
+        .post('/dictionaries')
+        .send(dictRequest)
+        .end((err: Error, res: Response) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(400);
+          setImmediate(done);
+        });
+    });
   });
 
   describe('Read', () => {

--- a/test/integration/crudIntegrationTests.ts
+++ b/test/integration/crudIntegrationTests.ts
@@ -204,7 +204,7 @@ describe('CRUD', () => {
         });
     });
 
-    it.only('Should get a dictionary with references hidden by default', (done: Mocha.Done) => {
+    it('Should get a dictionary with references hidden by default', (done: Mocha.Done) => {
       chai
         .request(app)
         .get('/dictionaries/' + id)
@@ -223,7 +223,7 @@ describe('CRUD', () => {
         });
     });
 
-    it.only('Should get a dictionary with references shown when requested', (done: Mocha.Done) => {
+    it('Should get a dictionary with references shown when requested', (done: Mocha.Done) => {
       chai
         .request(app)
         .get(`/dictionaries/${id}?references=true`)

--- a/test/integration/crudIntegrationTests.ts
+++ b/test/integration/crudIntegrationTests.ts
@@ -204,6 +204,44 @@ describe('CRUD', () => {
         });
     });
 
+    it.only('Should get a dictionary with references hidden by default', (done: Mocha.Done) => {
+      chai
+        .request(app)
+        .get('/dictionaries/' + id)
+        .end((err: Error, res: Response) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(200);
+          expect(res.body.references).to.not.exist;
+          const schemaWithReference = res.body.schemas.find(
+            (schema: any) => schema.name === 'registration',
+          );
+          const fieldWithReference = schemaWithReference.fields.find(
+            (field: any) => field.name === 'gender',
+          );
+          expect(fieldWithReference.restrictions.codeList).to.be.an('array');
+          setImmediate(done);
+        });
+    });
+
+    it.only('Should get a dictionary with references shown when requested', (done: Mocha.Done) => {
+      chai
+        .request(app)
+        .get(`/dictionaries/${id}?references=true`)
+        .end((err: Error, res: Response) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(200);
+          expect(res.body.references).to.exist;
+          const schemaWithReference = res.body.schemas.find(
+            (schema: any) => schema.name === 'registration',
+          );
+          const fieldWithReference = schemaWithReference.fields.find(
+            (field: any) => field.name === 'gender',
+          );
+          expect(fieldWithReference.restrictions.codeList).to.be.a('string');
+          setImmediate(done);
+        });
+    });
+
     it('Should 400 with a badly formed dictionary id', (done: Mocha.Done) => {
       chai
         .request(app)

--- a/test/integration/fixtures/createDictionary.json
+++ b/test/integration/fixtures/createDictionary.json
@@ -36,7 +36,7 @@
           "description": "The gender of the patient",
           "restrictions": {
             "required": true,
-            "codeList": ["Male", "Female", "Other"]
+            "codeList": "#/enums/gender"
           }
         },
         {
@@ -137,5 +137,6 @@
         }
       ]
     }
-  ]
+  ],
+  "references": { "enums": { "gender": ["Male", "Female", "Other"] } }
 }

--- a/test/integration/fixtures/createKeyValueBadReferenceFormat.json
+++ b/test/integration/fixtures/createKeyValueBadReferenceFormat.json
@@ -48,7 +48,7 @@
           },
           "restrictions": {
             "required": true,
-            "codeList": "#/enums/test"
+            "codeList": "/enums/test"
           }
         },
         {

--- a/test/integration/fixtures/createKeyValueBadReferenceValueType.json
+++ b/test/integration/fixtures/createKeyValueBadReferenceValueType.json
@@ -2,8 +2,8 @@
   "name": "Key Value Meta",
   "version": "1.0",
   "references": {
-    "enums": {
-      "test": ["foo", "bar", "biz"]
+    "scripts": {
+      "test": "someMethod()"
     }
   },
   "schemas": [
@@ -48,7 +48,7 @@
           },
           "restrictions": {
             "required": true,
-            "codeList": "#/enums/test"
+            "codeList": "#/scripts/test"
           }
         },
         {

--- a/test/integration/fixtures/createKeyValueBadUnknownReference.json
+++ b/test/integration/fixtures/createKeyValueBadUnknownReference.json
@@ -48,7 +48,7 @@
           },
           "restrictions": {
             "required": true,
-            "codeList": "#/enums/test"
+            "codeList": "#/enums/tests"
           }
         },
         {


### PR DESCRIPTION
Allow dictionaries to have a 'references' object and do on the fly replacement of reference variables in the schema.

Reference variables are of the form `#/any/path_to/value`. The dictionary must include a property called `references` that includes a value at the given path: ex: 

```
{
  "references": {
    "any": {
      "path_to": {
        "value": "Actual value to use in schema"
      }
    }
  }
}
```

All api calls to read the dictionary will by default replace the reference variables and hide the references property. Adding the query parameter `references=true` to the request will skip the variable replace so you can read the stored references. This change is therefore completely backwards compatible with all services currently integrated with lectern - no change will be noticed. Swagger documentation has been updated to reflect these changes.

Validation of schemas has been updated to perform the variable replacement before running validation, so if any variable references are incorrect (missing the reference value) or provide an invalid value for that field then the schema will fail validation.

