### PR TITLE
make script accept arrays of strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lectern",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config/MetaSchema.json
+++ b/src/config/MetaSchema.json
@@ -42,7 +42,17 @@
           "type": "boolean"
         },
         "script": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            { "type": "string", "pattern": "^#(\\/[-_A-Za-z0-9]+)+$" }
+          ]
         },
         "regex": {
           "type": "string"


### PR DESCRIPTION
For the `script` field, the meta-schema enforces two values
- an array of strings
- a regex string pointing to a reference 
___
- I think Jenkins is failing because of [npm being down ](https://status.npmjs.org/)

goes hand in hand with:
https://github.com/icgc-argo/argo-clinical/pull/373
https://github.com/icgc-argo/argo-dictionary/pull/48

