### PR TITLE
increase json limit from 100kb to 10mb

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,7 @@ const App = (config: AppConfig): Express => {
 
   app.set('port', serverPort);
 
-  app.use(bodyParser.json());
+  app.use(bodyParser.json({limit: '10mb'}));
   app.use(
     bodyParser.urlencoded({
       extended: true,


### PR DESCRIPTION
Default was 100kb, too limiting.

Bump it to 10mb for the time-being.