### PR TITLE
allow integer and number to have script field

### DIFF
--- a/src/config/MetaSchema.json
+++ b/src/config/MetaSchema.json
@@ -86,6 +86,19 @@
         "required": {
           "type": "boolean"
         },
+        "script": {
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            { "type": "string", "pattern": "^#(\\/[-_A-Za-z0-9]+)+$" }
+          ]
+        },
         "codeList": {
           "type": "array",
           "minItems": 2,
@@ -183,7 +196,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "numberMeta": {
       "type": "object",
@@ -210,6 +224,19 @@
       "properties": {
         "required": {
           "type": "boolean"
+        },
+        "script": {
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            { "type": "string", "pattern": "^#(\\/[-_A-Za-z0-9]+)+$" }
+          ]
         },
         "codeList": {
           "type": "array",

--- a/src/services/schemaService.ts
+++ b/src/services/schemaService.ts
@@ -30,7 +30,6 @@ export function validate(schema: any, references: any) {
     jsonPointers: true,
   });
   const validate = ajv.compile(MetaSchema);
-  const metaSchemaValid = validate(schemaWithReplacements);
 
   return { valid: validate(schemaWithReplacements), errors: validate.errors };
 }

--- a/test/integration/fixtures/updateNewFile.json
+++ b/test/integration/fixtures/updateNewFile.json
@@ -30,7 +30,7 @@
         "units": "days"
       },
       "restrictions": {
-        "script": "validateWithMagic(check dependece on another field)",
+        "script": ["validateWithMagic(check dependece on another field)"],
         "range": {
           "min": 0,
           "max": 99999


### PR DESCRIPTION
This PR adds `script` into `integerRestrictions` and `numberRestrictions` in metaschema,  this will allow dictionary to have number and integer fields to have `script` field. 