### PR TITLE
Feat/#472 normalize new lines

### DIFF
--- a/src/services/schemaService.ts
+++ b/src/services/schemaService.ts
@@ -34,19 +34,31 @@ export function validate(schema: any, references: any) {
   return { valid: validate(schemaWithReplacements), errors: validate.errors };
 }
 
+function normalizeScript(script: string | string[]) {
+  if (typeof script === 'string') {
+    return script.replace(/\r\n/g, '\n');
+  } else if (Array.isArray(script)) {
+    return script.map((s: string) => s.replace(/\r\n/g, '\n'));
+  } else {
+    return script;
+  }
+}
+
 export function normalizeSchema(schema: any) {
+  if (!schema.fields) return schema;
   return {
     ...schema,
     fields: schema.fields.map((field: any) => {
-      return field.restrictions && field.restrictions.script
-        ? {
-            ...field,
-            restrictions: {
-              ...field.restrictions,
-              script: field.restrictions.script.toString().replaceAll('\r\n', '\n'),
-            },
-          }
-        : field;
+      if (field.restrictions && field.restrictions.script) {
+        return {
+          ...field,
+          restrictions: {
+            ...field.restrictions,
+            script: normalizeScript(field.restrictions.script),
+          },
+        };
+      }
+      return field;
     }),
   };
 }

--- a/src/services/schemaService.ts
+++ b/src/services/schemaService.ts
@@ -43,7 +43,7 @@ export function normalizeSchema(schema: any) {
             ...field,
             restrictions: {
               ...field.restrictions,
-              script: field.restrictions.script.replaceAll('\r\n', '\n'),
+              script: field.restrictions.script.toString().replaceAll('\r\n', '\n'),
             },
           }
         : field;

--- a/test/functional/fixtures/linebreak/input1.json
+++ b/test/functional/fixtures/linebreak/input1.json
@@ -10,7 +10,9 @@
           "name": "cause_of_death",
           "valueType": "string",
           "description": "Cause of Donor Death",
-          "script": "(function(){\nreturn true;\n\n\n\n}())"
+          "restrictions": {
+            "script": "(function(){\nreturn true;\n\n\n\n}())"
+          }
         }
       ]
     }

--- a/test/functional/fixtures/linebreak/input1.json
+++ b/test/functional/fixtures/linebreak/input1.json
@@ -1,0 +1,18 @@
+{
+  "name": "ARGO Dictionary",
+  "version": "1.2",
+  "schemas": [
+    {
+      "name": "donor",
+      "description": "Donor Entity",
+      "fields": [
+        {
+          "name": "cause_of_death",
+          "valueType": "string",
+          "description": "Cause of Donor Death",
+          "script": "(function(){\nreturn true;\n\n\n\n}())"
+        }
+      ]
+    }
+  ]
+}

--- a/test/functional/fixtures/linebreak/input2.json
+++ b/test/functional/fixtures/linebreak/input2.json
@@ -1,0 +1,18 @@
+{
+  "name": "ARGO Dictionary",
+  "version": "1.2",
+  "schemas": [
+    {
+      "name": "donor",
+      "description": "Donor Entity",
+      "fields": [
+        {
+          "name": "cause_of_death",
+          "valueType": "string",
+          "description": "Cause of Donor Death",
+          "script": "(function(){\r\nreturn true;\r\n\r\n\r\n\r\n}())"
+        }
+      ]
+    }
+  ]
+}

--- a/test/functional/fixtures/linebreak/input2.json
+++ b/test/functional/fixtures/linebreak/input2.json
@@ -10,7 +10,9 @@
           "name": "cause_of_death",
           "valueType": "string",
           "description": "Cause of Donor Death",
-          "script": "(function(){\r\nreturn true;\r\n\r\n\r\n\r\n}())"
+          "restrictions": {
+            "script": "(function(){\r\nreturn true;\r\n\r\n\r\n\r\n}())"
+          }
         }
       ]
     }

--- a/test/functional/fixtures/linebreak/output.json
+++ b/test/functional/fixtures/linebreak/output.json
@@ -10,7 +10,9 @@
           "name": "cause_of_death",
           "valueType": "string",
           "description": "Cause of Donor Death",
-          "script": "(function(){\nreturn true;\n\n\n\n}())"
+          "restrictions": {
+            "script": "(function(){\nreturn true;\n\n\n\n}())"
+          }
         }
       ]
     }

--- a/test/functional/fixtures/linebreak/output.json
+++ b/test/functional/fixtures/linebreak/output.json
@@ -1,0 +1,18 @@
+{
+  "name": "ARGO Dictionary",
+  "version": "1.2",
+  "schemas": [
+    {
+      "name": "donor",
+      "description": "Donor Entity",
+      "fields": [
+        {
+          "name": "cause_of_death",
+          "valueType": "string",
+          "description": "Cause of Donor Death",
+          "script": "(function(){\nreturn true;\n\n\n\n}())"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`fields: restrictions: script` can end up having either `\r\n\` or `\n` line endings.
This adds line ending normalising to `\n` for schema update, schema addition, dictionary addition
