### PR TITLE
Meta properties can be nested

### DIFF
--- a/apps/server/test/integration/dictionaryRoutes.spec.ts
+++ b/apps/server/test/integration/dictionaryRoutes.spec.ts
@@ -136,7 +136,7 @@ describe('Dictionary Routes', () => {
 				});
 		});
 
-		it('Should 400 with meta fields that are not string/boolean/integer/number', (done: Mocha.Done) => {
+		it('Should 400 with meta fields that are arrays of objects', (done: Mocha.Done) => {
 			const dictRequest = require('./fixtures/createKeyValueBad.json');
 			chai
 				.request(app)

--- a/apps/server/test/integration/fixtures/createKeyValue.json
+++ b/apps/server/test/integration/fixtures/createKeyValue.json
@@ -17,7 +17,9 @@
 					"description": "kv_id",
 					"meta": {
 						"key": true,
-						"displayName": "KEY VALUE ID"
+						"displayName": "KEY VALUE ID",
+						"arraysOk": ["arrays", "are", "ok"],
+						"nested": { "key": "value", "number": 123, "bool": false }
 					},
 					"restrictions": {
 						"required": true,

--- a/apps/server/test/integration/fixtures/createKeyValueBad.json
+++ b/apps/server/test/integration/fixtures/createKeyValueBad.json
@@ -13,7 +13,12 @@
 					"meta": {
 						"key": true,
 						"displayName": "KEY VALUE ID",
-						"noArrays": ["lol", "sorry", "no_arrays", "please"]
+						"arraysOk": ["arrays", "are", "ok"],
+						"nested": { "key": "value", "number": 123, "bool": false },
+						"errorArrayOfObjects": [
+							{ "a": "b", "c": 4 },
+							{ "e": "f", "g": 8 }
+						]
 					},
 					"restrictions": {
 						"required": true,

--- a/generated/DictionaryMetaSchema.json
+++ b/generated/DictionaryMetaSchema.json
@@ -38,10 +38,35 @@
     "Meta": {
       "type": "object",
       "additionalProperties": {
-        "type": [
-          "string",
-          "number",
-          "boolean"
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            ]
+          },
+          {
+            "$ref": "#/definitions/Meta"
+          }
         ]
       }
     },

--- a/libraries/dictionary/src/types/dictionaryTypes.ts
+++ b/libraries/dictionary/src/types/dictionaryTypes.ts
@@ -29,7 +29,7 @@ export type NameString = zod.infer<typeof NameString>;
 
 export const Integer = zod.number().int();
 
-// Meta accepts as values only stirngs, numbers, booleans, arrays of numbers or arrays of strings
+// Meta accepts as values only strings, numbers, booleans, arrays of numbers or arrays of strings
 // Another Meta object can be nested inside a Meta property
 export const DictionaryMetaValue = zod.union([
 	zod.string(),

--- a/libraries/dictionary/src/types/dictionaryTypes.ts
+++ b/libraries/dictionary/src/types/dictionaryTypes.ts
@@ -29,11 +29,20 @@ export type NameString = zod.infer<typeof NameString>;
 
 export const Integer = zod.number().int();
 
-// Unlike references, meta is not nested and accepts as values only primitives or arrays of them.
-export const DictionaryMetaValue = zod.union([zod.string(), zod.number(), zod.boolean()]);
+// Meta accepts as values only stirngs, numbers, booleans, arrays of numbers or arrays of strings
+// Another Meta object can be nested inside a Meta property
+export const DictionaryMetaValue = zod.union([
+	zod.string(),
+	zod.number(),
+	zod.boolean(),
+	zod.array(zod.string()),
+	zod.array(zod.number()),
+]);
 export type DictionaryMetaValue = zod.infer<typeof DictionaryMetaValue>;
-export const DictionaryMeta = zod.record(DictionaryMetaValue);
-export type DictionaryMeta = zod.infer<typeof DictionaryMeta>;
+export type DictionaryMeta = { [key: string]: DictionaryMetaValue | DictionaryMeta };
+export const DictionaryMeta: zod.ZodType<DictionaryMeta> = zod.record(
+	zod.union([DictionaryMetaValue, zod.lazy(() => DictionaryMeta)]),
+);
 
 export const SchemaFieldValueType = zod.enum(['string', 'integer', 'number', 'boolean']);
 export type SchemaFieldValueType = zod.infer<typeof SchemaFieldValueType>;

--- a/libraries/dictionary/src/types/referenceTypes.ts
+++ b/libraries/dictionary/src/types/referenceTypes.ts
@@ -37,7 +37,7 @@ export type ReferenceArray = zod.infer<typeof ReferenceArray>;
 // References are recursive, but Zod can't do TS type inference for recursive definitions.
 // So in this one case we define the type first with the recursive structure and use it as a type-hint
 // for our zod schema. Reference: https://zod.dev/?id=recursive-types
-export type References = { [x: string]: ReferenceArray | ReferenceValue | References };
+export type References = { [key: string]: ReferenceArray | ReferenceValue | References };
 export const References: zod.ZodType<References> = zod.record(
 	zod.union([ReferenceValue, ReferenceArray, zod.lazy(() => References)]), //TODO: test this please.
 );

--- a/libraries/dictionary/test/dictionaryTypes.spec.ts
+++ b/libraries/dictionary/test/dictionaryTypes.spec.ts
@@ -21,6 +21,7 @@ import { expect } from 'chai';
 import {
 	BooleanFieldRestrictions,
 	Dictionary,
+	DictionaryMeta,
 	Integer,
 	IntegerFieldRestrictions,
 	NameString,
@@ -469,6 +470,36 @@ describe('Dictionary Types', () => {
 				};
 				expect(Dictionary.safeParse(dictionary).success).false;
 			});
+		});
+	});
+	describe('Meta', () => {
+		it('Can accept non-nested values', () => {
+			const meta = { a: 'string', b: 123, c: true };
+			expect(DictionaryMeta.safeParse(meta).success).true;
+		});
+		it('Can accept nested values', () => {
+			const singleNested = { a: 'string', b: 123, c: true, nested: { d: 'asdf' } };
+			const doubleNested = { a: 'string', b: 123, c: true, nested: { d: 'asdf', nested2: { e: 'asdf' } } };
+			expect(DictionaryMeta.safeParse(singleNested).success).true;
+			expect(DictionaryMeta.safeParse(doubleNested).success).true;
+		});
+		it('Can accept arrays of strings', () => {
+			const meta = { a: 'string', b: 123, c: true, array: ['asdf', 'qwerty'] };
+			expect(DictionaryMeta.safeParse(meta).success).true;
+		});
+		it('Can accept arrays of numbers', () => {
+			const meta = { a: 'string', b: 123, c: true, array: [123, 456, 789] };
+			expect(DictionaryMeta.safeParse(meta).success).true;
+		});
+		it('Cannot accept arrays of booleans', () => {
+			// This constraint feels a bit arbitrary but I can't imagine a clear use case for this.
+			// Could be changed with discussion
+			const meta = { a: 'string', b: 123, c: true, array: [true, false, true, false] };
+			expect(DictionaryMeta.safeParse(meta).success).false;
+		});
+		it('Cannot accept arrays of mixed types', () => {
+			const meta = { a: 'string', b: 123, c: true, array: ['asdf', 123] };
+			expect(DictionaryMeta.safeParse(meta).success).false;
 		});
 	});
 });


### PR DESCRIPTION
Issue: https://github.com/overture-stack/lectern/issues/200

This change allows values inside `meta` properties to be nested objects. This done recursively so that any level of nesting is possible.

This is achieved by updating the zod schema for the DictionaryMeta type, which is re-used for all uses of meta properties, including in the Dictionary, in all Schemas, and in all Fields.

Additionally, the allowed types of meta values was extended to also allow arrays of strings, and arrays of numbers. Arrays of mixed types and arrays of booleans are still not allowed.