### PR TITLE
Update property names in RecordError and TestResult types

### DIFF
--- a/docs/important-concepts.md
+++ b/docs/important-concepts.md
@@ -52,7 +52,7 @@ Placeholder
 
 Reference: [validation/src/types/testResult.ts](../packages/validation/src/types/testResult.ts)
 
-A `TestResult` represents the outcome of a validation test applied to an object. For example, a [`Field`](#field) will be validated based on its[Restrictions](#field-restriction) and this will generate a `TestResult` that will contain a list of `ValidationTestErrors` if the field is found to be invalid for one or more reasons.
+A `TestResult` represents the outcome of a validation test applied to an object. For example, a [`Field`](#field) will be validated based on its [Restrictions](#field-restriction) and this will generate a `TestResult` that will contain a list of `ValidationTestErrors` if the field is found to be invalid for one or more reasons.
 
 The TestResult object indicates if the object tested was **valid** or **invalid** (`valid: true`) for the given test. When the value is **invalid**, additional information should be included in the result that describes the conditions that the test failed.
 
@@ -69,7 +69,7 @@ Example Invalid `TestResult`, for a field validation that failed due to CodeList
 ```ts
 {
 	valid: false,
-	info: {
+	details: {
 		reason: "INVALID_BY_RESTRICTION",
 		value: "Atari",
 		errors: [

--- a/packages/client/src/processing/index.ts
+++ b/packages/client/src/processing/index.ts
@@ -37,7 +37,7 @@ export const processDictionary = (
 	if (!convertResult.success) {
 		return {
 			status: 'ERROR_CONVERSION',
-			data: convertResult.data,
+			data: convertResult.data, // TODO: data with errors, name needs to be better. details?
 		};
 	}
 
@@ -55,7 +55,7 @@ export const processDictionary = (
 		return {
 			status: 'ERROR_VALIDATION',
 			data: convertedData,
-			errors: validationResult.info,
+			errors: validationResult.details,
 		};
 	}
 
@@ -91,7 +91,7 @@ export const processSchema = (records: UnprocessedDataRecord[], schema: Schema):
 		return {
 			status: 'ERROR_VALIDATION',
 			records: convertedRecords,
-			errors: validationResult.info,
+			errors: validationResult.details,
 		};
 	}
 
@@ -125,7 +125,7 @@ export const processRecord = (schema: Schema, data: UnprocessedDataRecord): Reco
 		return {
 			status: 'ERROR_VALIDATION',
 			record,
-			errors: validationResult.info,
+			errors: validationResult.details,
 		};
 	}
 

--- a/packages/validation/src/convertValues/convertValues.ts
+++ b/packages/validation/src/convertValues/convertValues.ts
@@ -197,7 +197,7 @@ export function convertRecordValues(record: UnprocessedDataRecord, schema: Schem
 			errors.push({
 				reason: 'UNRECOGNIZED_FIELD',
 				fieldName,
-				value: stringValue,
+				fieldValue: stringValue,
 			});
 			continue;
 		}
@@ -209,7 +209,7 @@ export function convertRecordValues(record: UnprocessedDataRecord, schema: Schem
 			errors.push({
 				reason: 'INVALID_VALUE_TYPE',
 				fieldName,
-				value: stringValue,
+				fieldValue: stringValue,
 				isArray: !!fieldDefinition.isArray,
 				valueType: fieldDefinition.valueType,
 			});

--- a/packages/validation/src/types/testResult.ts
+++ b/packages/validation/src/types/testResult.ts
@@ -24,7 +24,7 @@ export const valid = (): TestResultValid => ({ valid: true });
 
 export type TestResultInvalid<T> = {
 	valid: false;
-	info: T;
+	details: T;
 };
 
 /**
@@ -35,7 +35,7 @@ export type TestResultInvalid<T> = {
  */
 export const invalid = <InvalidInfo>(info: InvalidInfo): TestResultInvalid<InvalidInfo> => ({
 	valid: false,
-	info,
+	details: info,
 });
 
 /**

--- a/packages/validation/src/validateDictionary/testForeignKeyRestriction.ts
+++ b/packages/validation/src/validateDictionary/testForeignKeyRestriction.ts
@@ -48,7 +48,7 @@ export const testForeignKeyRestriction = (
 							reason: 'INVALID_BY_FOREIGNKEY',
 							fieldName: foreignKeyMapping.local,
 							foreignSchema: { fieldName: foreignKeyMapping.foreign, schemaName: restriction.schema },
-							value: localValue,
+							fieldValue: localValue,
 						};
 			})
 			.filter(isDefined);

--- a/packages/validation/src/validateDictionary/validateDictionary.ts
+++ b/packages/validation/src/validateDictionary/validateDictionary.ts
@@ -62,7 +62,7 @@ export const validateDictionary = (
 	const unrecognizedSchemaErrors = Object.keys(data)
 		.map((schemaName) => testUnrecognizedSchema(schemaName, dictionary))
 		.filter((result) => !result.valid)
-		.map((result) => result.info);
+		.map((result) => result.details);
 
 	const foreignSchemaReferenceData = collectSchemaReferenceData(data, dictionary);
 
@@ -85,13 +85,13 @@ export const validateDictionary = (
 							}
 							return {
 								recordIndex,
-								recordErrors: foreignKeyTestResult.info,
+								recordErrors: foreignKeyTestResult.details,
 							};
 						})
 						.filter(isDefined)
 				: [];
 			const combinedErrors = mergeSchemaRecordValidationErrors<DictionaryValidationRecordErrorDetails>(
-				schemaValidationResult.valid ? [] : schemaValidationResult.info,
+				schemaValidationResult.valid ? [] : schemaValidationResult.details,
 				foreignKeyErrors,
 			);
 

--- a/packages/validation/src/validateField/validateField.ts
+++ b/packages/validation/src/validateField/validateField.ts
@@ -70,7 +70,7 @@ const applyFieldRestrictionTests = (
 		if (!result.valid) {
 			output.push({
 				restriction,
-				...result.info,
+				...result.details,
 			});
 		}
 		return output;

--- a/packages/validation/src/validateRecord/RecordValidationError.ts
+++ b/packages/validation/src/validateRecord/RecordValidationError.ts
@@ -25,7 +25,7 @@ import type {
 
 export type FieldDetails = {
 	fieldName: string;
-	value: DataRecordValue;
+	fieldValue: DataRecordValue;
 };
 
 export type RecordValidationErrorInvalidValue = FieldDetails & FieldValidationErrorValueType;

--- a/packages/validation/src/validateRecord/validateRecord.ts
+++ b/packages/validation/src/validateRecord/validateRecord.ts
@@ -47,7 +47,7 @@ export const validateRecord = (record: DataRecord, schema: Schema): TestResult<R
 					reason: 'UNRECOGNIZED_FIELD',
 
 					fieldName,
-					value,
+					fieldValue: value,
 				});
 			}
 			return output;
@@ -66,7 +66,7 @@ export const validateRecord = (record: DataRecord, schema: Schema): TestResult<R
 			fieldValidationResult.info;
 			output.push({
 				fieldName,
-				value,
+				fieldValue: value,
 				...fieldValidationResult.info,
 			});
 		}

--- a/packages/validation/src/validateRecord/validateRecord.ts
+++ b/packages/validation/src/validateRecord/validateRecord.ts
@@ -45,7 +45,6 @@ export const validateRecord = (record: DataRecord, schema: Schema): TestResult<R
 			if (!schema.fields.some((field) => field.name === fieldName)) {
 				output.push({
 					reason: 'UNRECOGNIZED_FIELD',
-
 					fieldName,
 					fieldValue: value,
 				});
@@ -63,11 +62,11 @@ export const validateRecord = (record: DataRecord, schema: Schema): TestResult<R
 
 		const fieldValidationResult = validateField(value, record, field);
 		if (!fieldValidationResult.valid) {
-			fieldValidationResult.info;
+			fieldValidationResult.details;
 			output.push({
 				fieldName,
 				fieldValue: value,
-				...fieldValidationResult.info,
+				...fieldValidationResult.details,
 			});
 		}
 		return output;

--- a/packages/validation/src/validateSchema/restrictions/uniqueField/testUniqueFieldRestriction.ts
+++ b/packages/validation/src/validateSchema/restrictions/uniqueField/testUniqueFieldRestriction.ts
@@ -32,16 +32,16 @@ import type { SchemaValidationRecordErrorUnique } from '../../SchemaValidationEr
  * @returns
  */
 export const testUniqueFieldRestriction = (
-	value: DataRecordValue,
+	fieldValue: DataRecordValue,
 	fieldName: string,
 	uniqueKeyMap: Map<string, number[]>,
 ): TestResult<SchemaValidationRecordErrorUnique> => {
 	// Only apply unique field restriction when a value is provided
-	if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+	if (fieldValue === undefined || (Array.isArray(fieldValue) && fieldValue.length === 0)) {
 		return valid();
 	}
 	// Build unique key for this record, based on the fields listed in the rule
-	const hash = hashDataRecord({ [fieldName]: value });
+	const hash = hashDataRecord({ [fieldName]: fieldValue });
 
 	// Lookup the key in the provided map. Report errors when the map has more than one record index found for this hash
 	const matchingRecords = uniqueKeyMap.get(hash);
@@ -49,7 +49,7 @@ export const testUniqueFieldRestriction = (
 		return invalid({
 			reason: 'INVALID_BY_UNIQUE',
 			fieldName,
-			value,
+			fieldValue,
 			matchingRecords,
 		});
 	}

--- a/packages/validation/src/validateSchema/validateSchema.ts
+++ b/packages/validation/src/validateSchema/validateSchema.ts
@@ -64,21 +64,21 @@ export const validateSchema = (records: Array<DataRecord>, schema: Schema): Test
 			const uniqueKeyResult =
 				uniqueKeyMap && uniqueKeyRule ? testUniqueKey(record, uniqueKeyRule, uniqueKeyMap) : valid();
 			if (!uniqueKeyResult.valid) {
-				recordErrors.push(uniqueKeyResult.info);
+				recordErrors.push(uniqueKeyResult.details);
 			}
 
 			// Unique Field Restriction Tests
 			uniqueFieldMaps.forEach((hashMap, fieldName) => {
 				const uniqueFieldResult = testUniqueFieldRestriction(record[fieldName], fieldName, hashMap);
 				if (!uniqueFieldResult.valid) {
-					recordErrors.push(uniqueFieldResult.info);
+					recordErrors.push(uniqueFieldResult.details);
 				}
 			});
 
 			// Data Record validation
 			const recordValidationResult = validateRecord(record, schema);
 			if (!recordValidationResult.valid) {
-				recordErrors.push(...recordValidationResult.info);
+				recordErrors.push(...recordValidationResult.details);
 			}
 			return recordErrors.length ? { recordIndex, recordErrors } : undefined;
 		})

--- a/packages/validation/test/convertValues/convertRecord.spec.ts
+++ b/packages/validation/test/convertValues/convertRecord.spec.ts
@@ -61,12 +61,12 @@ describe('Convert Values - convertRecordValues', () => {
 		const anyNumberError = result.data.errors.find((error) => error.fieldName === 'any-number');
 		expect(anyNumberError).not.undefined;
 		assert(anyNumberError !== undefined);
-		expect(anyNumberError.value).equal('NaN');
+		expect(anyNumberError.fieldValue).equal('NaN');
 
 		const anyIntegerError = result.data.errors.find((error) => error.fieldName === 'any-integer');
 		expect(anyIntegerError).not.undefined;
 		assert(anyIntegerError !== undefined);
-		expect(anyIntegerError.value).equal('12.34');
+		expect(anyIntegerError.fieldValue).equal('12.34');
 
 		const anyBooleanError = result.data.errors.find((error) => error.fieldName === 'any-boolean');
 		expect(anyBooleanError).not.undefined;
@@ -104,6 +104,6 @@ describe('Convert Values - convertRecordValues', () => {
 		assert(unrecognizedFieldError !== undefined);
 		expect(unrecognizedFieldError.reason).equal('UNRECOGNIZED_FIELD');
 		expect(unrecognizedFieldError.fieldName).equal('unrecognized-field');
-		expect(unrecognizedFieldError.value).equal('true');
+		expect(unrecognizedFieldError.fieldValue).equal('true');
 	});
 });

--- a/packages/validation/test/validateDictionary/validateDictionary.spec.ts
+++ b/packages/validation/test/validateDictionary/validateDictionary.spec.ts
@@ -65,9 +65,9 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'Only one schema found invalid.').equal(1);
-			expect(result.info[0]?.reason).equal('UNRECOGNIZED_SCHEMA');
-			expect(result.info[0]?.schemaName, 'Correctly names the unrecognized schema.').equal(wrongSchemaName);
+			expect(result.details.length, 'Only one schema found invalid.').equal(1);
+			expect(result.details[0]?.reason).equal('UNRECOGNIZED_SCHEMA');
+			expect(result.details[0]?.schemaName, 'Correctly names the unrecognized schema.').equal(wrongSchemaName);
 		});
 		it('Invalid with correct data type rules', () => {
 			const schemaName = dictionarySingleSchemaNoRestrictions.schemas[0].name;
@@ -79,16 +79,16 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'Only one schema found invalid.').equal(1);
-			expect(result.info[0]?.schemaName, 'Correctly names schema with error.').equal(schemaName);
-			expect(result.info[0]?.reason).equal('INVALID_RECORDS');
-			expect((result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordIndex).equal(0);
+			expect(result.details.length, 'Only one schema found invalid.').equal(1);
+			expect(result.details[0]?.schemaName, 'Correctly names schema with error.').equal(schemaName);
+			expect(result.details[0]?.reason).equal('INVALID_RECORDS');
+			expect((result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordIndex).equal(0);
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordErrors.length,
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordErrors.length,
 				'Only one error found for field.',
 			).equal(1);
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordErrors[0]?.reason,
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords[0]?.recordErrors[0]?.reason,
 			).equal('INVALID_VALUE_TYPE');
 		});
 		it('Invalid with schema uniqueKey restriction', () => {
@@ -105,33 +105,33 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'Only one schema found invalid.').equal(1);
-			expect(result.info[0]?.schemaName, 'Correctly names schema with error.').equal(schemaName);
-			expect(result.info[0]?.reason).equal('INVALID_RECORDS');
+			expect(result.details.length, 'Only one schema found invalid.').equal(1);
+			expect(result.details[0]?.schemaName, 'Correctly names schema with error.').equal(schemaName);
+			expect(result.details[0]?.reason).equal('INVALID_RECORDS');
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.length,
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.length,
 				'Correct number of invalid records reported.',
 			).equal(2);
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.some(
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.some(
 					(invalidRecord) => invalidRecord.recordIndex === 0,
 				),
 				'Record 0 should be reported as invalid',
 			).true;
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.some(
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.some(
 					(invalidRecord) => invalidRecord.recordIndex === 2,
 				),
 				'Record 2 should be reported as invalid',
 			).true;
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.every(
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.every(
 					(invalidRecord) => invalidRecord.recordErrors.length === 1,
 				),
 				'Only one error for each invalid record',
 			).true;
 			expect(
-				(result.info[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.every(
+				(result.details[0] as DictionaryValidationErrorInvalidRecords).invalidRecords.every(
 					(invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY',
 				),
 				'Every invalid record is by unique key',
@@ -172,9 +172,9 @@ describe('Dictionary - validateDictionary', () => {
 			const result = validateDictionary(dataSet, dictionaryMultipleSchemasNoRestrictions);
 			expect(result.valid).false;
 			assert(result.valid === false);
-			expect(result.info.length, 'One error for each schema.').equal(2);
+			expect(result.details.length, 'One error for each schema.').equal(2);
 
-			const singleStringSchemaResult = result.info.find((result) => result.schemaName === 'single-string');
+			const singleStringSchemaResult = result.details.find((result) => result.schemaName === 'single-string');
 			expect(singleStringSchemaResult).not.undefined;
 			assert(singleStringSchemaResult !== undefined);
 			expect(singleStringSchemaResult.reason).equal('INVALID_RECORDS');
@@ -184,7 +184,7 @@ describe('Dictionary - validateDictionary', () => {
 				'Should be 3 invalid fields in single-string schema',
 			).equal(3);
 
-			const allDataSchemaResult = result.info.find((result) => result.schemaName === 'all-data-types');
+			const allDataSchemaResult = result.details.find((result) => result.schemaName === 'all-data-types');
 			expect(allDataSchemaResult).not.undefined;
 			assert(allDataSchemaResult !== undefined);
 			expect(allDataSchemaResult.reason).equal('INVALID_RECORDS');
@@ -218,9 +218,9 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info[0]?.reason === 'UNRECOGNIZED_SCHEMA');
-			assert(result.info[0] !== undefined && result.info[0].reason === 'UNRECOGNIZED_SCHEMA');
-			expect(result.info[0].schemaName).equal(invalidSchemaName);
+			expect(result.details[0]?.reason === 'UNRECOGNIZED_SCHEMA');
+			assert(result.details[0] !== undefined && result.details[0].reason === 'UNRECOGNIZED_SCHEMA');
+			expect(result.details[0].schemaName).equal(invalidSchemaName);
 		});
 	});
 	describe('Multiple Schemas, foreignKey restrictions', () => {
@@ -252,18 +252,18 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.reason).equal('INVALID_RECORDS');
-			assert(result.info[0]?.reason === 'INVALID_RECORDS');
-			expect(result.info[0].invalidRecords.length, 'Only 1 invalid record').equal(1);
-			expect(result.info[0].invalidRecords[0]?.recordIndex).equal(0);
-			expect(result.info[0].invalidRecords[0]?.recordErrors.length, 'Only 1 error on this record').equal(1);
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.reason).equal('INVALID_BY_FOREIGNKEY');
-			assert(result.info[0].invalidRecords[0]?.recordErrors[0]?.reason === 'INVALID_BY_FOREIGNKEY');
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.fieldName).equal('string-with-foreign-key');
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.fieldValue).equal('invalid value');
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.schemaName).equal('all-data-types');
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.fieldName).equal('any-string');
+			expect(result.details.length).equal(1);
+			expect(result.details[0]?.reason).equal('INVALID_RECORDS');
+			assert(result.details[0]?.reason === 'INVALID_RECORDS');
+			expect(result.details[0].invalidRecords.length, 'Only 1 invalid record').equal(1);
+			expect(result.details[0].invalidRecords[0]?.recordIndex).equal(0);
+			expect(result.details[0].invalidRecords[0]?.recordErrors.length, 'Only 1 error on this record').equal(1);
+			expect(result.details[0].invalidRecords[0]?.recordErrors[0]?.reason).equal('INVALID_BY_FOREIGNKEY');
+			assert(result.details[0].invalidRecords[0]?.recordErrors[0]?.reason === 'INVALID_BY_FOREIGNKEY');
+			expect(result.details[0].invalidRecords[0]?.recordErrors[0]?.fieldName).equal('string-with-foreign-key');
+			expect(result.details[0].invalidRecords[0]?.recordErrors[0]?.fieldValue).equal('invalid value');
+			expect(result.details[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.schemaName).equal('all-data-types');
+			expect(result.details[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.fieldName).equal('any-string');
 		});
 		it('Foreign key restriction not applied to undefined values', () => {
 			const dataSet = {
@@ -309,17 +309,17 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'One schema with errors').equal(1);
-			expect(result.info[0]?.reason).equal('INVALID_RECORDS');
-			assert(result.info[0]?.reason === 'INVALID_RECORDS');
+			expect(result.details.length, 'One schema with errors').equal(1);
+			expect(result.details[0]?.reason).equal('INVALID_RECORDS');
+			assert(result.details[0]?.reason === 'INVALID_RECORDS');
 
-			expect(result.info[0].schemaName).equal('multiple-foreign-keys');
-			expect(result.info[0].invalidRecords.length, 'Expect 3 records to fail the foreign key restriction').equal(3);
+			expect(result.details[0].schemaName).equal('multiple-foreign-keys');
+			expect(result.details[0].invalidRecords.length, 'Expect 3 records to fail the foreign key restriction').equal(3);
 
 			// Index 0 has no errors
-			expect(result.info[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 0)).undefined;
+			expect(result.details[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 0)).undefined;
 
-			const errorIndex1 = result.info[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 1);
+			const errorIndex1 = result.details[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 1);
 			expect(errorIndex1).not.undefined;
 			assert(errorIndex1 !== undefined);
 			expect(errorIndex1.recordErrors.length).equal(1);
@@ -330,7 +330,7 @@ describe('Dictionary - validateDictionary', () => {
 			expect(errorIndex1.recordErrors[0].fieldName).equal('string-field');
 			expect(errorIndex1.recordErrors[0].fieldValue).equal('lkjh');
 
-			const errorIndex2 = result.info[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 2);
+			const errorIndex2 = result.details[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 2);
 			expect(errorIndex2).not.undefined;
 			assert(errorIndex2 !== undefined);
 			expect(errorIndex2.recordErrors.length).equal(2);
@@ -351,7 +351,7 @@ describe('Dictionary - validateDictionary', () => {
 				'Expect one foreign key error vs single-string schema',
 			).not.undefined;
 
-			const errorIndex3 = result.info[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 3);
+			const errorIndex3 = result.details[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 3);
 			expect(errorIndex3).not.undefined;
 			assert(errorIndex3 !== undefined);
 			expect(errorIndex3.recordErrors.length).equal(1);
@@ -371,20 +371,20 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.reason).equal('INVALID_RECORDS');
-			assert(result.info[0]?.reason === 'INVALID_RECORDS');
-			expect(result.info[0].invalidRecords.length, 'Only 1 invalid record').equal(1);
-			expect(result.info[0].invalidRecords[0]?.recordIndex).equal(0);
-			expect(result.info[0].invalidRecords[0]?.recordErrors.length, 'Expect 2 errors on this record').equal(2);
+			expect(result.details.length).equal(1);
+			expect(result.details[0]?.reason).equal('INVALID_RECORDS');
+			assert(result.details[0]?.reason === 'INVALID_RECORDS');
+			expect(result.details[0].invalidRecords.length, 'Only 1 invalid record').equal(1);
+			expect(result.details[0].invalidRecords[0]?.recordIndex).equal(0);
+			expect(result.details[0].invalidRecords[0]?.recordErrors.length, 'Expect 2 errors on this record').equal(2);
 
-			const valueTypeError = result.info[0].invalidRecords[0]?.recordErrors.find(
+			const valueTypeError = result.details[0].invalidRecords[0]?.recordErrors.find(
 				(recordError) => recordError.reason === 'INVALID_VALUE_TYPE',
 			);
 			expect(valueTypeError).not.undefined;
 			assert(valueTypeError !== undefined);
 
-			const foreignKeyError = result.info[0].invalidRecords[0]?.recordErrors.find(
+			const foreignKeyError = result.details[0].invalidRecords[0]?.recordErrors.find(
 				(recordError) => recordError.reason === 'INVALID_BY_FOREIGNKEY',
 			);
 			expect(foreignKeyError).not.undefined;

--- a/packages/validation/test/validateDictionary/validateDictionary.spec.ts
+++ b/packages/validation/test/validateDictionary/validateDictionary.spec.ts
@@ -261,7 +261,7 @@ describe('Dictionary - validateDictionary', () => {
 			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.reason).equal('INVALID_BY_FOREIGNKEY');
 			assert(result.info[0].invalidRecords[0]?.recordErrors[0]?.reason === 'INVALID_BY_FOREIGNKEY');
 			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.fieldName).equal('string-with-foreign-key');
-			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.value).equal('invalid value');
+			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.fieldValue).equal('invalid value');
 			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.schemaName).equal('all-data-types');
 			expect(result.info[0].invalidRecords[0]?.recordErrors[0]?.foreignSchema.fieldName).equal('any-string');
 		});
@@ -328,7 +328,7 @@ describe('Dictionary - validateDictionary', () => {
 			expect(errorIndex1.recordErrors[0].foreignSchema.schemaName).equal('all-data-types');
 			expect(errorIndex1.recordErrors[0].foreignSchema.fieldName).equal('any-string');
 			expect(errorIndex1.recordErrors[0].fieldName).equal('string-field');
-			expect(errorIndex1.recordErrors[0].value).equal('lkjh');
+			expect(errorIndex1.recordErrors[0].fieldValue).equal('lkjh');
 
 			const errorIndex2 = result.info[0].invalidRecords.find((invalidRecord) => invalidRecord.recordIndex === 2);
 			expect(errorIndex2).not.undefined;
@@ -360,7 +360,7 @@ describe('Dictionary - validateDictionary', () => {
 			expect(errorIndex3.recordErrors[0].foreignSchema.schemaName).equal('all-data-types');
 			expect(errorIndex3.recordErrors[0].foreignSchema.fieldName).equal('any-number');
 			expect(errorIndex3.recordErrors[0].fieldName).equal('number-field');
-			expect(errorIndex3.recordErrors[0].value).equal(0);
+			expect(errorIndex3.recordErrors[0].fieldValue).equal(0);
 		});
 		it('Invalid with mix of foreign key and field validation errors', () => {
 			const dataSet = {

--- a/packages/validation/test/validateField/restrictions/testCodeList.spec.ts
+++ b/packages/validation/test/validateField/restrictions/testCodeList.spec.ts
@@ -113,14 +113,14 @@ describe('Field - Restrictions - testCodeList', () => {
 			expect(result.valid).false;
 			assert(!result.valid);
 
-			expect(Array.isArray(result.info.invalidItems)).true;
-			assert(Array.isArray(result.info.invalidItems));
+			expect(Array.isArray(result.details.invalidItems)).true;
+			assert(Array.isArray(result.details.invalidItems));
 
-			expect(result.info.invalidItems.length).equal(2);
-			expect(result.info.invalidItems[0]?.position).equal(0);
-			expect(result.info.invalidItems[0]?.value).equal('linux');
-			expect(result.info.invalidItems[1]?.position).equal(2);
-			expect(result.info.invalidItems[1]?.value).equal('turnip');
+			expect(result.details.invalidItems.length).equal(2);
+			expect(result.details.invalidItems[0]?.position).equal(0);
+			expect(result.details.invalidItems[0]?.value).equal('linux');
+			expect(result.details.invalidItems[1]?.position).equal(2);
+			expect(result.details.invalidItems[1]?.value).equal('turnip');
 		});
 	});
 });

--- a/packages/validation/test/validateField/restrictions/testRegex.spec.ts
+++ b/packages/validation/test/validateField/restrictions/testRegex.spec.ts
@@ -74,16 +74,16 @@ describe('Field - Restrictions - testRegex', () => {
 			expect(result.valid).false;
 			assert(!result.valid);
 
-			expect(Array.isArray(result.info.invalidItems)).true;
-			assert(Array.isArray(result.info.invalidItems));
+			expect(Array.isArray(result.details.invalidItems)).true;
+			assert(Array.isArray(result.details.invalidItems));
 
-			expect(result.info.invalidItems.length).equal(3);
-			expect(result.info.invalidItems[0]?.position).equal(validDateArray.length);
-			expect(result.info.invalidItems[0]?.value).equal('invalid');
-			expect(result.info.invalidItems[1]?.position).equal(validDateArray.length + 2);
-			expect(result.info.invalidItems[1]?.value).equal('another invalid');
-			expect(result.info.invalidItems[2]?.position).equal(validDateArray.length + 3);
-			expect(result.info.invalidItems[2]?.value).equal('third invalid');
+			expect(result.details.invalidItems.length).equal(3);
+			expect(result.details.invalidItems[0]?.position).equal(validDateArray.length);
+			expect(result.details.invalidItems[0]?.value).equal('invalid');
+			expect(result.details.invalidItems[1]?.position).equal(validDateArray.length + 2);
+			expect(result.details.invalidItems[1]?.value).equal('another invalid');
+			expect(result.details.invalidItems[2]?.position).equal(validDateArray.length + 3);
+			expect(result.details.invalidItems[2]?.value).equal('third invalid');
 		});
 	});
 });

--- a/packages/validation/test/validateField/validateField.spec.ts
+++ b/packages/validation/test/validateField/validateField.spec.ts
@@ -69,11 +69,11 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(!result.valid);
 
-				expect(result.info.reason).equal('INVALID_VALUE_TYPE');
-				assert(result.info.reason === 'INVALID_VALUE_TYPE');
+				expect(result.details.reason).equal('INVALID_VALUE_TYPE');
+				assert(result.details.reason === 'INVALID_VALUE_TYPE');
 
-				expect(result.info.isArray).equal(!!testField.isArray); // needs the !! to convert to boolean since `testField.isArray` is undefined
-				expect(result.info.valueType).equal(testField.valueType);
+				expect(result.details.isArray).equal(!!testField.isArray); // needs the !! to convert to boolean since `testField.isArray` is undefined
+				expect(result.details.valueType).equal(testField.valueType);
 			});
 		});
 		describe('Boolean type, no restrictions', () => {
@@ -162,14 +162,14 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('codeList');
-				expect(result.info.errors[0]?.restriction.rule).deep.equal(fieldStringCodeList.restrictions?.codeList);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('codeList');
+				expect(result.details.errors[0]?.restriction.rule).deep.equal(fieldStringCodeList.restrictions?.codeList);
 			});
 		});
 		describe('String with Regex', () => {
@@ -182,10 +182,10 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
-				expect(result.info.errors[0]?.restriction.type).equal('regex');
-				expect(result.info.errors[0]?.restriction.rule).equal(fieldStringRegex.restrictions?.regex);
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.errors[0]?.restriction.type).equal('regex');
+				expect(result.details.errors[0]?.restriction.rule).equal(fieldStringRegex.restrictions?.regex);
 			});
 		});
 		describe('String with Required', () => {
@@ -200,14 +200,14 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('required');
-				expect(result.info.errors[0]?.restriction.rule).equal(fieldStringRequired.restrictions?.required);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('required');
+				expect(result.details.errors[0]?.restriction.rule).equal(fieldStringRequired.restrictions?.required);
 			});
 		});
 		describe('Number with Range', () => {
@@ -229,14 +229,14 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('range');
-				expect(result.info.errors[0]?.restriction.rule).equal(fieldNumberRange.restrictions?.range);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('range');
+				expect(result.details.errors[0]?.restriction.rule).equal(fieldNumberRange.restrictions?.range);
 			});
 		});
 		describe('String Array with Required', () => {
@@ -251,14 +251,14 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('required');
-				expect(result.info.errors[0]?.restriction.rule).equal(fieldStringArrayRequired.restrictions?.required);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('required');
+				expect(result.details.errors[0]?.restriction.rule).equal(fieldStringArrayRequired.restrictions?.required);
 			});
 			it('Invalid when array has an empty string', () => {
 				const testValue = ['this array has an illegal value', ''];
@@ -266,18 +266,18 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('required');
-				expect(result.info.errors[0]?.restriction.rule).equal(fieldStringArrayRequired.restrictions?.required);
-				expect(Array.isArray(result.info.errors[0]?.invalidItems)).true;
-				assert(Array.isArray(result.info.errors[0]?.invalidItems));
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('required');
+				expect(result.details.errors[0]?.restriction.rule).equal(fieldStringArrayRequired.restrictions?.required);
+				expect(Array.isArray(result.details.errors[0]?.invalidItems)).true;
+				assert(Array.isArray(result.details.errors[0]?.invalidItems));
 
-				expect(result.info.errors[0]?.invalidItems[0]?.position).equal(1);
-				expect(result.info.errors[0]?.invalidItems[0]?.value).equal('');
+				expect(result.details.errors[0]?.invalidItems[0]?.position).equal(1);
+				expect(result.details.errors[0]?.invalidItems[0]?.value).equal('');
 			});
 		});
 		describe('Number Array with codeList', () => {
@@ -300,19 +300,19 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('codeList');
-				expect(result.info.errors[0]?.restriction.rule).deep.equal(fieldNumberArrayCodeList.restrictions?.codeList);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('codeList');
+				expect(result.details.errors[0]?.restriction.rule).deep.equal(fieldNumberArrayCodeList.restrictions?.codeList);
 
-				expect(Array.isArray(result.info.errors[0]?.invalidItems)).true;
-				assert(Array.isArray(result.info.errors[0]?.invalidItems));
+				expect(Array.isArray(result.details.errors[0]?.invalidItems)).true;
+				assert(Array.isArray(result.details.errors[0]?.invalidItems));
 
-				expect(result.info.errors[0]?.invalidItems[0]?.position).equal(4);
-				expect(result.info.errors[0]?.invalidItems[0]?.value).equal(4);
+				expect(result.details.errors[0]?.invalidItems[0]?.position).equal(4);
+				expect(result.details.errors[0]?.invalidItems[0]?.value).equal(4);
 			});
 		});
 	});
@@ -328,55 +328,59 @@ describe('Field - validateField', () => {
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('codeList');
-				expect(result.info.errors[0]?.restriction.rule).deep.equal(fieldStringManyRestrictions.restrictions?.codeList);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('codeList');
+				expect(result.details.errors[0]?.restriction.rule).deep.equal(
+					fieldStringManyRestrictions.restrictions?.codeList,
+				);
 			});
 			it('Invalid when failing regex condition', () => {
 				const result = validateField('April 4, 2004', emptyDataRecord, fieldStringManyRestrictions);
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('regex');
-				expect(result.info.errors[0]?.restriction.rule).deep.equal(fieldStringManyRestrictions.restrictions?.regex);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('regex');
+				expect(result.details.errors[0]?.restriction.rule).deep.equal(fieldStringManyRestrictions.restrictions?.regex);
 			});
 			it('Invalid when failing required condition', () => {
 				const result = validateField(undefined, emptyDataRecord, fieldStringManyRestrictions);
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(1);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				expect(result.info.errors[0]?.restriction.type).equal('required');
-				expect(result.info.errors[0]?.restriction.rule).deep.equal(fieldStringManyRestrictions.restrictions?.required);
+				expect(result.details.errors.length).equal(1);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				expect(result.details.errors[0]?.restriction.type).equal('required');
+				expect(result.details.errors[0]?.restriction.rule).deep.equal(
+					fieldStringManyRestrictions.restrictions?.required,
+				);
 			});
 			it('Invalid when failing regex and codeList restrictions', () => {
 				const result = validateField('this value is wrong', emptyDataRecord, fieldStringManyRestrictions);
 				expect(result.valid).false;
 				assert(result.valid === false);
 
-				expect(result.info.reason).equal('INVALID_BY_RESTRICTION');
-				assert(result.info.reason === 'INVALID_BY_RESTRICTION');
+				expect(result.details.reason).equal('INVALID_BY_RESTRICTION');
+				assert(result.details.reason === 'INVALID_BY_RESTRICTION');
 
-				expect(result.info.errors.length).equal(2);
-				expect(result.info.errors[0]?.message).not.undefined;
-				expect(result.info.errors[0]?.invalidItems).undefined;
-				const errors = result.info.errors;
+				expect(result.details.errors.length).equal(2);
+				expect(result.details.errors[0]?.message).not.undefined;
+				expect(result.details.errors[0]?.invalidItems).undefined;
+				const errors = result.details.errors;
 				const regexError = errors.find(
 					(error) =>
 						error.restriction.type === 'regex' &&

--- a/packages/validation/test/validateRecord/validateRecord.spec.ts
+++ b/packages/validation/test/validateRecord/validateRecord.spec.ts
@@ -56,10 +56,10 @@ describe('Record - validateRecord', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.reason).equal('UNRECOGNIZED_FIELD');
-			expect(result.info[0]?.fieldName).equal(unknownFieldName);
-			expect(result.info[0]?.fieldValue).equal(unknownFieldValue);
+			expect(result.details.length).equal(1);
+			expect(result.details[0]?.reason).equal('UNRECOGNIZED_FIELD');
+			expect(result.details[0]?.fieldName).equal(unknownFieldName);
+			expect(result.details[0]?.fieldValue).equal(unknownFieldValue);
 		});
 		it('Invalid with multiple unrecognized fields, reports each error', () => {
 			const unknownFieldNameA = 'unknown-field-name-a';
@@ -73,14 +73,14 @@ describe('Record - validateRecord', () => {
 			assert(result.valid === false);
 
 			// Confirmed result is invalid, make sure we have multiple unrecognized field errors with the correct info
-			expect(result.info.length).equal(2);
-			const fieldErrorA = result.info.find((error) => error.fieldName === unknownFieldNameA);
+			expect(result.details.length).equal(2);
+			const fieldErrorA = result.details.find((error) => error.fieldName === unknownFieldNameA);
 			expect(fieldErrorA).not.undefined;
 			assert(fieldErrorA !== undefined);
 			expect(fieldErrorA.reason).equal('UNRECOGNIZED_FIELD');
 			expect(fieldErrorA.fieldValue).equal(record[unknownFieldNameA]);
 
-			const fieldErrorB = result.info.find((error) => error.fieldName === unknownFieldNameB);
+			const fieldErrorB = result.details.find((error) => error.fieldName === unknownFieldNameB);
 			expect(fieldErrorB).not.undefined;
 			assert(fieldErrorB !== undefined);
 			expect(fieldErrorB.reason).equal('UNRECOGNIZED_FIELD');
@@ -94,10 +94,10 @@ describe('Record - validateRecord', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.reason).equal('INVALID_BY_RESTRICTION');
-			expect(result.info[0]?.fieldName).equal('string-required');
-			expect(result.info[0]?.fieldValue).equal(undefined);
+			expect(result.details.length).equal(1);
+			expect(result.details[0]?.reason).equal('INVALID_BY_RESTRICTION');
+			expect(result.details[0]?.fieldName).equal('string-required');
+			expect(result.details[0]?.fieldValue).equal(undefined);
 		});
 
 		it('Invalid with multiple missing required fields, reports each error', () => {
@@ -105,12 +105,12 @@ describe('Record - validateRecord', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(4);
+			expect(result.details.length).equal(4);
 
-			const fieldError0 = result.info.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[0].name);
-			const fieldError1 = result.info.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[1].name);
-			const fieldError2 = result.info.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[2].name);
-			const fieldError3 = result.info.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[3].name);
+			const fieldError0 = result.details.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[0].name);
+			const fieldError1 = result.details.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[1].name);
+			const fieldError2 = result.details.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[2].name);
+			const fieldError3 = result.details.find((error) => error.fieldName === schemaAllDataTypesRequired.fields[3].name);
 			expect(fieldError0).not.undefined;
 			expect(fieldError1).not.undefined;
 			expect(fieldError2).not.undefined;
@@ -147,13 +147,15 @@ describe('Record - validateRecord', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(3);
+			expect(result.details.length).equal(3);
 
-			const fieldErrorStringMany = result.info.find((error) => error.fieldName === fieldStringManyRestrictions.name);
+			const fieldErrorStringMany = result.details.find((error) => error.fieldName === fieldStringManyRestrictions.name);
 			expect(fieldErrorStringMany).not.undefined;
-			const fieldErrorNumberCodeList = result.info.find((error) => error.fieldName === fieldNumberArrayCodeList.name);
+			const fieldErrorNumberCodeList = result.details.find(
+				(error) => error.fieldName === fieldNumberArrayCodeList.name,
+			);
 			expect(fieldErrorNumberCodeList).not.undefined;
-			const fieldErrorIntegerRequired = result.info.find((error) => error.fieldName === fieldIntegerRequired.name);
+			const fieldErrorIntegerRequired = result.details.find((error) => error.fieldName === fieldIntegerRequired.name);
 			expect(fieldErrorIntegerRequired).not.undefined;
 			assert(
 				fieldErrorStringMany !== undefined &&
@@ -184,10 +186,10 @@ describe('Record - validateRecord', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(2);
+			expect(result.details.length).equal(2);
 
-			const fieldValueError = result.info.find((error) => error.fieldName === 'number-code-list');
-			const unknownFieldError = result.info.find((error) => error.fieldName === 'unknown-field');
+			const fieldValueError = result.details.find((error) => error.fieldName === 'number-code-list');
+			const unknownFieldError = result.details.find((error) => error.fieldName === 'unknown-field');
 			expect(fieldValueError).not.undefined;
 			expect(unknownFieldError).not.undefined;
 			assert(fieldValueError !== undefined && unknownFieldError !== undefined);

--- a/packages/validation/test/validateRecord/validateRecord.spec.ts
+++ b/packages/validation/test/validateRecord/validateRecord.spec.ts
@@ -59,7 +59,7 @@ describe('Record - validateRecord', () => {
 			expect(result.info.length).equal(1);
 			expect(result.info[0]?.reason).equal('UNRECOGNIZED_FIELD');
 			expect(result.info[0]?.fieldName).equal(unknownFieldName);
-			expect(result.info[0]?.value).equal(unknownFieldValue);
+			expect(result.info[0]?.fieldValue).equal(unknownFieldValue);
 		});
 		it('Invalid with multiple unrecognized fields, reports each error', () => {
 			const unknownFieldNameA = 'unknown-field-name-a';
@@ -78,13 +78,13 @@ describe('Record - validateRecord', () => {
 			expect(fieldErrorA).not.undefined;
 			assert(fieldErrorA !== undefined);
 			expect(fieldErrorA.reason).equal('UNRECOGNIZED_FIELD');
-			expect(fieldErrorA.value).equal(record[unknownFieldNameA]);
+			expect(fieldErrorA.fieldValue).equal(record[unknownFieldNameA]);
 
 			const fieldErrorB = result.info.find((error) => error.fieldName === unknownFieldNameB);
 			expect(fieldErrorB).not.undefined;
 			assert(fieldErrorB !== undefined);
 			expect(fieldErrorB.reason).equal('UNRECOGNIZED_FIELD');
-			expect(fieldErrorB.value).equal(record[unknownFieldNameB]);
+			expect(fieldErrorB.fieldValue).equal(record[unknownFieldNameB]);
 		});
 	});
 
@@ -97,7 +97,7 @@ describe('Record - validateRecord', () => {
 			expect(result.info.length).equal(1);
 			expect(result.info[0]?.reason).equal('INVALID_BY_RESTRICTION');
 			expect(result.info[0]?.fieldName).equal('string-required');
-			expect(result.info[0]?.value).equal(undefined);
+			expect(result.info[0]?.fieldValue).equal(undefined);
 		});
 
 		it('Invalid with multiple missing required fields, reports each error', () => {
@@ -123,13 +123,13 @@ describe('Record - validateRecord', () => {
 			);
 
 			expect(fieldError0.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldError0.value).equal(undefined);
+			expect(fieldError0.fieldValue).equal(undefined);
 			expect(fieldError1.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldError1.value).equal(undefined);
+			expect(fieldError1.fieldValue).equal(undefined);
 			expect(fieldError2.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldError2.value).equal(undefined);
+			expect(fieldError2.fieldValue).equal(undefined);
 			expect(fieldError3.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldError3.value).equal(undefined);
+			expect(fieldError3.fieldValue).equal(undefined);
 
 			// each of these errors will have fieldValidationErrors inside them which are validated in validateField.spec.ts
 		});
@@ -162,11 +162,11 @@ describe('Record - validateRecord', () => {
 			);
 
 			expect(fieldErrorStringMany.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldErrorStringMany.value).equal('this value is wrong');
+			expect(fieldErrorStringMany.fieldValue).equal('this value is wrong');
 			expect(fieldErrorNumberCodeList.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldErrorNumberCodeList.value).deep.equal([1.61803, 2.41421, 0]);
+			expect(fieldErrorNumberCodeList.fieldValue).deep.equal([1.61803, 2.41421, 0]);
 			expect(fieldErrorIntegerRequired.reason).equal('INVALID_BY_RESTRICTION');
-			expect(fieldErrorIntegerRequired.value).equal(undefined);
+			expect(fieldErrorIntegerRequired.fieldValue).equal(undefined);
 		});
 	});
 	describe('Mixed Errors', () => {
@@ -193,10 +193,10 @@ describe('Record - validateRecord', () => {
 			assert(fieldValueError !== undefined && unknownFieldError !== undefined);
 
 			expect(fieldValueError.reason).equal('INVALID_VALUE_TYPE');
-			expect(fieldValueError.value).equal('should be a number');
+			expect(fieldValueError.fieldValue).equal('should be a number');
 
 			expect(unknownFieldError.reason).equal('UNRECOGNIZED_FIELD');
-			expect(unknownFieldError.value).equal(123);
+			expect(unknownFieldError.fieldValue).equal(123);
 		});
 	});
 });

--- a/packages/validation/test/validateSchema/validateSchema.spec.ts
+++ b/packages/validation/test/validateSchema/validateSchema.spec.ts
@@ -55,15 +55,15 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'There should be an invalid record for each field with a duplicate value').equal(
+			expect(result.details.length, 'There should be an invalid record for each field with a duplicate value').equal(
 				records.length,
 			);
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
 				'Each invalid record should have a single error',
 			).true;
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE'),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE'),
 				'Every invalid record should have a unique restriction error',
 			).true;
 		});
@@ -124,12 +124,13 @@ describe('Schema - validateSchema', () => {
 				const result = validateSchema(records, schemaUniqueStringArray);
 				expect(result.valid).false;
 				assert(result.valid === false);
-				expect(result.info.length).equal(5);
+				expect(result.details.length).equal(5);
 
 				const failedIndices = [2, 3, 6, 7, 8];
 				const allIndicesListed = failedIndices.every(
 					(index) =>
-						result.info.find((error) => error.recordIndex === index)?.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE',
+						result.details.find((error) => error.recordIndex === index)?.recordErrors[0]?.reason ===
+						'INVALID_BY_UNIQUE',
 				);
 				expect(allIndicesListed).true;
 			});
@@ -178,35 +179,35 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'There should be an invalid record for each field with a duplicate value').equal(
+			expect(result.details.length, 'There should be an invalid record for each field with a duplicate value').equal(
 				records.length,
 			);
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
 				'Each invalid record should have a single error',
 			).true;
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
 				'Every invalid record should have a uniqueKey error',
 			).true;
 			assert(
-				result.info[0] !== undefined &&
-					result.info[0].recordErrors[0] !== undefined &&
-					result.info[0].recordErrors[0].reason === 'INVALID_BY_UNIQUE_KEY',
+				result.details[0] !== undefined &&
+					result.details[0].recordErrors[0] !== undefined &&
+					result.details[0].recordErrors[0].reason === 'INVALID_BY_UNIQUE_KEY',
 			);
 			assert(
-				result.info[1] !== undefined &&
-					result.info[1].recordErrors[0] !== undefined &&
-					result.info[1].recordErrors[0].reason === 'INVALID_BY_UNIQUE_KEY',
+				result.details[1] !== undefined &&
+					result.details[1].recordErrors[0] !== undefined &&
+					result.details[1].recordErrors[0].reason === 'INVALID_BY_UNIQUE_KEY',
 			);
 
-			expect(result.info[0].recordErrors[0].uniqueKey).deep.equal({ ...repeatedRecord });
-			expect(result.info[0].recordErrors[0].matchingRecords).include(0);
-			expect(result.info[0].recordErrors[0].matchingRecords).include(1);
+			expect(result.details[0].recordErrors[0].uniqueKey).deep.equal({ ...repeatedRecord });
+			expect(result.details[0].recordErrors[0].matchingRecords).include(0);
+			expect(result.details[0].recordErrors[0].matchingRecords).include(1);
 
-			expect(result.info[1].recordErrors[0].uniqueKey).deep.equal({ ...repeatedRecord });
-			expect(result.info[1].recordErrors[0].matchingRecords).include(0);
-			expect(result.info[1].recordErrors[0].matchingRecords).include(1);
+			expect(result.details[1].recordErrors[0].uniqueKey).deep.equal({ ...repeatedRecord });
+			expect(result.details[1].recordErrors[0].matchingRecords).include(0);
+			expect(result.details[1].recordErrors[0].matchingRecords).include(1);
 		});
 		it('Invalid for repeated key including an undefined', () => {
 			const records: DataRecord[] = [
@@ -217,15 +218,15 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'There should be an invalid record for each field with a duplicate value').equal(
+			expect(result.details.length, 'There should be an invalid record for each field with a duplicate value').equal(
 				records.length,
 			);
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
 				'Each invalid record should have a single error',
 			).true;
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
 				'Every invalid record should have a uniqueKey error',
 			).true;
 		});
@@ -238,15 +239,15 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length, 'There should be an invalid record for each field with a duplicate value').equal(
+			expect(result.details.length, 'There should be an invalid record for each field with a duplicate value').equal(
 				records.length,
 			);
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors.length === 1),
 				'Each invalid record should have a single error',
 			).true;
 			expect(
-				result.info.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
+				result.details.every((invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_UNIQUE_KEY'),
 				'Every invalid record should have a uniqueKey error',
 			).true;
 		});
@@ -275,7 +276,7 @@ describe('Schema - validateSchema', () => {
 				const result = validateSchema(records, schemaUniqueKeyWithArray);
 				expect(result.valid).false;
 				assert(result.valid === false);
-				expect(result.info.length).equal(2);
+				expect(result.details.length).equal(2);
 			});
 			it('Invalid when repeated value is empty array', () => {
 				// first two records are duplicates
@@ -289,7 +290,7 @@ describe('Schema - validateSchema', () => {
 				const result = validateSchema(records, schemaUniqueKeyWithArray);
 				expect(result.valid).false;
 				assert(result.valid === false);
-				expect(result.info.length).equal(2);
+				expect(result.details.length).equal(2);
 			});
 		});
 	});
@@ -300,12 +301,13 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.recordIndex, 'Invalid record needs to indicate the correct position in the array.').equal(
-				1,
-			);
+			expect(result.details.length).equal(1);
 			expect(
-				result.info[0]?.recordErrors[0]?.reason,
+				result.details[0]?.recordIndex,
+				'Invalid record needs to indicate the correct position in the array.',
+			).equal(1);
+			expect(
+				result.details[0]?.recordErrors[0]?.reason,
 				'Invalid record needs to indicate it failed by restriction.',
 			).equal('INVALID_BY_RESTRICTION');
 		});
@@ -319,12 +321,13 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(1);
-			expect(result.info[0]?.recordIndex, 'Invalid record needs to indicate the correct position in the array.').equal(
-				2,
-			);
+			expect(result.details.length).equal(1);
 			expect(
-				result.info[0]?.recordErrors[0]?.reason,
+				result.details[0]?.recordIndex,
+				'Invalid record needs to indicate the correct position in the array.',
+			).equal(2);
+			expect(
+				result.details[0]?.recordErrors[0]?.reason,
 				'Invalid record needs to indicate it failed by invalid value type.',
 			).equal('INVALID_VALUE_TYPE');
 		});
@@ -339,15 +342,15 @@ describe('Schema - validateSchema', () => {
 			expect(result.valid).false;
 			assert(result.valid === false);
 
-			expect(result.info.length).equal(3);
+			expect(result.details.length).equal(3);
 
-			const missingValueRecord = result.info.find(
+			const missingValueRecord = result.details.find(
 				(invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_BY_RESTRICTION',
 			);
-			const invalidValueTypeRecord = result.info.find(
+			const invalidValueTypeRecord = result.details.find(
 				(invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'INVALID_VALUE_TYPE',
 			);
-			const unrecognizedFieldRecord = result.info.find(
+			const unrecognizedFieldRecord = result.details.find(
 				(invalidRecord) => invalidRecord.recordErrors[0]?.reason === 'UNRECOGNIZED_FIELD',
 			);
 


### PR DESCRIPTION
## Objective

Update the names of two properties that are commonly used and were ambiguous. This change is incorporating feedback from a review of the validation-refactor branch.

Two properties are changed, then all uses of those properties throughout the validation and client packages are updated to reflect this change:

- `TestResult` - The data returned with Invalid test results is now found under the property `details` instead of `info`
- `FieldDetails` - The shared data type of all `RecordValidationError` objects has the `value` property renamed to `fieldValue`