### PR TITLE
Release Candidate 2.0.0-beta.4

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@overture-stack/lectern-server",
 	"private": true,
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "Overture Data Dictionary Management",
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",

--- a/generated/DictionaryMetaSchema.json
+++ b/generated/DictionaryMetaSchema.json
@@ -10,6 +10,10 @@
         "description": {
           "type": "string"
         },
+        "delimiter": {
+          "type": "string",
+          "minLength": 1
+        },
         "isArray": {
           "type": "boolean"
         },
@@ -121,6 +125,9 @@
         },
         "description": {
           "$ref": "#/definitions/SchemaBooleanField/properties/description"
+        },
+        "delimiter": {
+          "$ref": "#/definitions/SchemaBooleanField/properties/delimiter"
         },
         "isArray": {
           "$ref": "#/definitions/SchemaBooleanField/properties/isArray"
@@ -234,6 +241,9 @@
         "description": {
           "$ref": "#/definitions/SchemaBooleanField/properties/description"
         },
+        "delimiter": {
+          "$ref": "#/definitions/SchemaBooleanField/properties/delimiter"
+        },
         "isArray": {
           "$ref": "#/definitions/SchemaBooleanField/properties/isArray"
         },
@@ -345,6 +355,9 @@
         },
         "description": {
           "$ref": "#/definitions/SchemaBooleanField/properties/description"
+        },
+        "delimiter": {
+          "$ref": "#/definitions/SchemaBooleanField/properties/delimiter"
         },
         "isArray": {
           "$ref": "#/definitions/SchemaBooleanField/properties/isArray"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@overture-stack/lectern",
 	"private": true,
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "Schema Manager and Validation for Data Dictionaries",
 	"scripts": {
 		"build:all": "pnpm nx run-many --all --target=build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@overture-stack/lectern-client",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"files": [
 		"dist/"
 	],

--- a/packages/client/src/rest/getDiff.ts
+++ b/packages/client/src/rest/getDiff.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { DictionaryDiffArray, failure, success, type Result } from '@overture-stack/lectern-dictionary';
+import axios, { AxiosError } from 'axios';
+import formatAxiosError from './formatAxiosError';
+
+const getDiffResponseSchema = DictionaryDiffArray;
+
+/**
+ * Fetches from a Lectern server the diff array between two versions of the same dictionary.
+ *
+ * This function requires a left (current) and right (previous) version of the dictionary to compare.
+ * If the server has both versions, then an array of all fields that have differences will be returned.
+ */
+export const getDiff = async (
+	lecternHost: string,
+	dictionary: { name: string; leftVersion: string; rightVersion: string },
+	options?: {
+		showReferences?: boolean;
+	},
+): Promise<Result<DictionaryDiffArray>> => {
+	try {
+		const diffResponse = await axios.request({
+			method: 'GET',
+			baseURL: lecternHost,
+			url: `/diff`,
+			params: {
+				name: dictionary.name,
+				left: dictionary.leftVersion,
+				right: dictionary.rightVersion,
+
+				references: options?.showReferences,
+			},
+		});
+
+		const parseResult = getDiffResponseSchema.safeParse(diffResponse.data);
+		if (!parseResult.success) {
+			console.log(parseResult.error.flatten);
+			return failure(
+				'Unable to parse response from server. Ensure that the Lectern client and server are using compatible versions.',
+			);
+		}
+		return success(parseResult.data);
+	} catch (error: unknown) {
+		if (error instanceof AxiosError) {
+			return failure(formatAxiosError(error));
+		}
+		return failure(`Unexpected error: ${error}`);
+	}
+};

--- a/packages/client/src/rest/index.ts
+++ b/packages/client/src/rest/index.ts
@@ -18,4 +18,5 @@
  */
 
 export * from './getDictionary';
+export * from './getDiff';
 export * from './listDictionaries';

--- a/packages/dictionary/package.json
+++ b/packages/dictionary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@overture-stack/lectern-dictionary",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "",
 	"files": [
 		"dist/"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@overture-stack/lectern-validation",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "Logic for validating data using a Lectern dictionary",
 	"files": [
 		"dist/"


### PR DESCRIPTION
## Description

This release makes the Lectern Client able to be run in the browser. It does this by removing breaking dependencies and by updating the Lectern Server to enable CORS requests.

A bug is also fixed that was causing the Lectern Server to not store dictionary description or meta data.

### Usage Notes

- To enable CORS for a lectern server requires providing the new environment variable `CORS_ALLOWED_DOMAINS`. To enable for all domains, use `CORS_ALLOWED_DOMAINS=*`. For a specific list of domains use `CORS_ALLOWED_DOMAINS=https://first.example.com,https://second.example.com`. See Lectern Server README for more details.

## Updates
- #233
- #247
- #248
- #249