### PR TITLE
#270: Table of Contents Dropdown Implementation + Dropdown styling cleanup

### DIFF
--- a/packages/ui/src/common/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/common/Dropdown/Dropdown.tsx
@@ -31,21 +31,20 @@ const dropdownButtonStyle = (theme: Theme, width?: string) => css`
 	display: flex;
 	flex-wrap: nowrap;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: center;
 	gap: 11px;
-	min-width: ${width || '200px'};
-	max-width: 400px;
-	width: 100%;
-	padding: 8px;
+	width: ${width || 'auto'};
+	min-width: fit-content;
+	padding: 8px 16px;
 	background-color: #f7f7f7;
 	color: ${theme.colors.black};
 	border: 1px solid #beb2b294;
 	border-radius: 9px;
 	font-size: 14px;
-	max-height: 42px;
+	height: 42px;
+	box-sizing: border-box;
 	cursor: pointer;
-	transition: background-color 0.2s ease;
-
+	transition: all 0.2s ease;
 	&:hover {
 		background-color: ${theme.colors.grey_1};
 	}
@@ -60,29 +59,22 @@ const chevronStyle = (open: boolean) => css`
 	transform: ${open ? 'rotate(180deg)' : 'none'};
 	transition: transform 0.2s ease;
 `;
-const dropDownTitleStyle = (theme: any) => css`
-	padding: 5px 10px;
-	font-weight: 400;
-	line-height: 100%;
-	letter-spacing: 0%;
+
+const dropDownTitleStyle = (theme: Theme) => css`
+	${theme.typography?.heading};
 	color: ${theme.colors.accent_dark};
 `;
 
 const dropdownMenuStyle = (theme: Theme) => css`
+	${theme.typography?.heading};
 	position: absolute;
 	top: calc(100% + 5px);
-	left: 0;
 	width: 100%;
 	background-color: #f7f7f7;
-	border: 1px solid ${theme.colors?.grey_1};
-	border-radius: 4px;
-	box-shadow:
-		0 1px 6px rgba(0, 0, 0, 0.1),
-		0 1px 5px rgba(0, 0, 0, 0.08);
-	list-style: none;
-	padding: 4px 0;
-	margin: 0;
-	z-index: 1000;
+	border: 1px solid #beb2b294;
+	border-radius: 9px;
+	padding-top: 5px;
+	padding-bottom: 5px;
 `;
 
 type MenuItem = {
@@ -102,8 +94,6 @@ const Dropdown = ({ menuItems = [], title, leftIcon }: DropDownProps) => {
 	const theme = useThemeContext();
 
 	const { ChevronDown } = theme.icons;
-
-	const hasMenuItems = menuItems.length > 0;
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -141,7 +131,7 @@ const Dropdown = ({ menuItems = [], title, leftIcon }: DropDownProps) => {
 					<ChevronDown fill={theme.colors?.black} width={18} height={18} style={chevronStyle(open)} />
 				</div>
 
-				{open && <ul css={dropdownMenuStyle(theme)}>{renderMenuItems()}</ul>}
+				{open && <div css={dropdownMenuStyle(theme)}>{renderMenuItems()}</div>}
 			</div>
 		</div>
 	);

--- a/packages/ui/src/common/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/common/Dropdown/Dropdown.tsx
@@ -37,7 +37,7 @@ const dropdownButtonStyle = (theme: Theme, width?: string) => css`
 	min-width: fit-content;
 	padding: 8px 16px;
 	background-color: #f7f7f7;
-	color: ${theme.colors.black};
+	color: ${theme.colors.accent_dark};
 	border: 1px solid #beb2b294;
 	border-radius: 9px;
 	font-size: 14px;
@@ -45,9 +45,6 @@ const dropdownButtonStyle = (theme: Theme, width?: string) => css`
 	box-sizing: border-box;
 	cursor: pointer;
 	transition: all 0.2s ease;
-	&:hover {
-		background-color: ${theme.colors.grey_1};
-	}
 `;
 
 const parentStyle = css`
@@ -72,8 +69,8 @@ const dropdownMenuStyle = (theme: Theme) => css`
 	width: 100%;
 	background-color: #f7f7f7;
 	border: 1px solid #beb2b294;
-	border-radius: 9px;
 	padding-top: 5px;
+	border-radius: 9px;
 	padding-bottom: 5px;
 `;
 
@@ -128,9 +125,10 @@ const Dropdown = ({ menuItems = [], title, leftIcon }: DropDownProps) => {
 				<div css={dropdownButtonStyle(theme)} onClick={handleToggle}>
 					{leftIcon}
 					<span css={dropDownTitleStyle(theme)}>{title}</span>
-					<ChevronDown fill={theme.colors?.black} width={18} height={18} style={chevronStyle(open)} />
+					<ChevronDown fill={theme.colors?.accent_dark} width={18} height={18} style={chevronStyle(open)} />
 				</div>
 
+				{/* {open && <>{renderMenuItems()}</>} */}
 				{open && <div css={dropdownMenuStyle(theme)}>{renderMenuItems()}</div>}
 			</div>
 		</div>

--- a/packages/ui/src/common/Dropdown/DropdownItem.tsx
+++ b/packages/ui/src/common/Dropdown/DropdownItem.tsx
@@ -40,10 +40,14 @@ const styledListItemStyle = (theme: Theme, customStyles?: any) => css`
 	min-height: 100%;
 	height: 100%;
 	align-items: center;
+	border-radius: 9px;
 	justify-content: center;
 	color: ${theme.colors.accent_dark};
 	cursor: pointer;
 	${customStyles?.base}
+	&:hover {
+		background-color: ${theme.colors.grey_1};
+	}
 `;
 
 const DropDownItem = ({ children, action, customStyles }: DropDownItemProps) => {
@@ -51,9 +55,9 @@ const DropDownItem = ({ children, action, customStyles }: DropDownItemProps) => 
 	const content = <div css={styledListItemStyle(theme, customStyles)}>{children}</div>;
 	if (typeof action === 'function') {
 		return (
-			<a onClick={action} css={styledListItemStyle(theme, customStyles)}>
+			<div className="dropdown-item" onClick={action} css={styledListItemStyle(theme, customStyles)}>
 				{children}
-			</a>
+			</div>
 		);
 	}
 

--- a/packages/ui/src/common/Dropdown/DropdownItem.tsx
+++ b/packages/ui/src/common/Dropdown/DropdownItem.tsx
@@ -37,21 +37,12 @@ type DropDownItemProps = {
 
 const styledListItemStyle = (theme: Theme, customStyles?: any) => css`
 	display: flex;
-	max-height: 42px;
 	min-height: 100%;
 	height: 100%;
 	align-items: center;
-	padding: 8px;
 	justify-content: center;
-	color: ${theme.colors?.black};
-	background-color: #f7f7f7;
-	border: 1px solid ${theme.colors.grey_1};
-	text-decoration: none;
+	color: ${theme.colors.accent_dark};
 	cursor: pointer;
-	border: none;
-	&:hover {
-		background-color: ${theme.colors.grey_2};
-	}
 	${customStyles?.base}
 `;
 

--- a/packages/ui/src/theme/icons/List.tsx
+++ b/packages/ui/src/theme/icons/List.tsx
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+import IconProps from './IconProps';
+
+const ChevronDown = ({ fill, width, height, style }: IconProps) => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={width || 24}
+			height={height || 24}
+			viewBox="0 0 24 24"
+			fill={fill || 'none'}
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			css={css`
+				${style}
+			`}
+		>
+			<path d="M3 12h.01" />
+			<path d="M3 18h.01" />
+			<path d="M3 6h.01" />
+			<path d="M8 12h13" />
+			<path d="M8 18h13" />
+			<path d="M8 6h13" />
+		</svg>
+	);
+};
+
+export default ChevronDown;

--- a/packages/ui/src/theme/styles/icons.ts
+++ b/packages/ui/src/theme/styles/icons.ts
@@ -1,4 +1,6 @@
 import ChevronDown from '../icons/ChevronDown';
+import List from '../icons/List';
 export default {
 	ChevronDown,
+	List,
 };

--- a/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
+++ b/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
@@ -4,17 +4,29 @@ import List from '../../theme/icons/List';
 
 type TableOfContentsDropdownProps = {
 	schemas: Schema[];
+	onSchemaSelect: (schema: Schema) => void;
+	onAccordionToggle: (schemaName: string, isOpen: boolean) => void;
 };
 
-const TableOfContentsDropdown = ({ schemas }: TableOfContentsDropdownProps) => {
+const TableOfContentsDropdown = ({ schemas, onSchemaSelect, onAccordionToggle }: TableOfContentsDropdownProps) => {
+	const handleAction = (schema: Schema) => {
+		const anchorId = `${schema.name}`;
+		onAccordionToggle(schema.name, true);
+		onSchemaSelect(schema);
+		setTimeout(() => {
+			window.location.hash = anchorId;
+		}, 100);
+	};
+
 	const generateOptionsFromSchemas = () => {
 		return schemas.map((schema) => ({
 			label: schema.name,
 			action: () => {
-				console.log(`Selected schema: ${schema.name}`);
+				handleAction(schema);
 			},
 		}));
 	};
+
 	return <Dropdown leftIcon={<List />} title="Table of Contents" menuItems={generateOptionsFromSchemas()} />;
 };
 

--- a/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
+++ b/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
@@ -1,0 +1,21 @@
+import type { Schema } from '@overture-stack/lectern-dictionary';
+import Dropdown from '../../common/Dropdown/Dropdown';
+import List from '../../theme/icons/List';
+
+type TableOfContentsDropdownProps = {
+	schemas: Schema[];
+};
+
+const TableOfContentsDropdown = ({ schemas }: TableOfContentsDropdownProps) => {
+	const generateOptionsFromSchemas = () => {
+		return schemas.map((schema) => ({
+			label: schema.name,
+			action: () => {
+				console.log(`Selected schema: ${schema.name}`);
+			},
+		}));
+	};
+	return <Dropdown leftIcon={<List />} title="Table of Contents" menuItems={generateOptionsFromSchemas()} />;
+};
+
+export default TableOfContentsDropdown;

--- a/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
+++ b/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
@@ -4,15 +4,13 @@ import List from '../../theme/icons/List';
 
 type TableOfContentsDropdownProps = {
 	schemas: Schema[];
-	onSchemaSelect: (schema: Schema) => void;
 	onAccordionToggle: (schemaName: string, isOpen: boolean) => void;
 };
 
-const TableOfContentsDropdown = ({ schemas, onSchemaSelect, onAccordionToggle }: TableOfContentsDropdownProps) => {
+const TableOfContentsDropdown = ({ schemas, onAccordionToggle }: TableOfContentsDropdownProps) => {
 	const handleAction = (schema: Schema) => {
 		const anchorId = `${schema.name}`;
-		onAccordionToggle(schema.name, true);
-		onSchemaSelect(schema);
+		onAccordionToggle(schema.name, true); // Ensuring that the accordion for the associated schema is open, via the state handler that will be defined in parent component
 		setTimeout(() => {
 			window.location.hash = anchorId;
 		}, 100);

--- a/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
+++ b/packages/ui/src/viewer-table/InteractionPanel/TableOfContentsDropdown.tsx
@@ -18,16 +18,14 @@ const TableOfContentsDropdown = ({ schemas, onSchemaSelect, onAccordionToggle }:
 		}, 100);
 	};
 
-	const generateOptionsFromSchemas = () => {
-		return schemas.map((schema) => ({
-			label: schema.name,
-			action: () => {
-				handleAction(schema);
-			},
-		}));
-	};
+	const menuItemsFromSchemas = schemas.map((schema) => ({
+		label: schema.name,
+		action: () => {
+			handleAction(schema);
+		},
+	}));
 
-	return <Dropdown leftIcon={<List />} title="Table of Contents" menuItems={generateOptionsFromSchemas()} />;
+	return <Dropdown leftIcon={<List />} title="Table of Contents" menuItems={menuItemsFromSchemas} />;
 };
 
 export default TableOfContentsDropdown;

--- a/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
+++ b/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
@@ -2,7 +2,7 @@
 
 import { Schema } from '@overture-stack/lectern-dictionary';
 import type { Meta, StoryObj } from '@storybook/react';
-import primitiveJson from '../../../../samples/schemas/primitives.json';
+import Dictionary from '../../../../samples/dictionary/advanced.json';
 import TableOfContentsDropdown from '../../src/viewer-table/InteractionPanel/TableOfContentsDropdown';
 import themeDecorator from '../themeDecorator';
 
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Using the primitiveJson as a mock schema for demonstration purposes
-const schema: Schema = primitiveJson as Schema;
+const schemas: Schema[] = Dictionary.schemas as Schema[];
 
 // Mock functions for the story just to demonstrate interaction
 
@@ -27,7 +27,7 @@ const onAccordionToggle = (schemaName: string, isOpen: boolean) => {
 
 export const Default: Story = {
 	args: {
-		schemas: [schema],
+		schemas: schemas,
 		onAccordionToggle,
 	},
 };

--- a/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
+++ b/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
@@ -1,0 +1,31 @@
+/** @jsxImportSource @emotion/react */
+
+import { Schema } from '@overture-stack/lectern-dictionary';
+import type { Meta, StoryObj } from '@storybook/react';
+import primitiveJson from '../../../../samples/schemas/primitives.json';
+import TableOfContentsDropdown from '../../src/viewer-table/InteractionPanel/TableOfContentsDropdown';
+import themeDecorator from '../themeDecorator';
+
+// Using the primitiveJson as a mock schema for demonstration purposes
+
+const schema: Schema = primitiveJson as Schema;
+
+const meta = {
+	component: TableOfContentsDropdown,
+	title: 'Viewer - Table/Table of Contents Dropdown',
+	tags: ['autodocs'],
+	decorators: [themeDecorator()],
+} satisfies Meta<typeof TableOfContentsDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		schemas: [schema],
+	},
+};
+
+export const Empty: Story = {
+	args: { schemas: [] },
+};

--- a/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
+++ b/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
@@ -21,22 +21,17 @@ const schema: Schema = primitiveJson as Schema;
 
 // Mock functions for the story just to demonstrate interaction
 
-const onSchemaSelect = (schema: Schema) => {
-	console.log('Selected schema:', schema);
-};
-
 const onAccordionToggle = (schemaName: string, isOpen: boolean) => {
-	console.log(`Accordion ${isOpen ? 'opened' : 'closed'} for schema:`, schemaName);
+	console.log('Accordion has been toggled for the following schema: ', schemaName);
 };
 
 export const Default: Story = {
 	args: {
 		schemas: [schema],
-		onSchemaSelect,
 		onAccordionToggle,
 	},
 };
 
 export const Empty: Story = {
-	args: { schemas: [], onSchemaSelect, onAccordionToggle },
+	args: { schemas: [], onAccordionToggle },
 };

--- a/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
+++ b/packages/ui/stories/viewer-table/TableOfContentDropdown.stories.tsx
@@ -6,10 +6,6 @@ import primitiveJson from '../../../../samples/schemas/primitives.json';
 import TableOfContentsDropdown from '../../src/viewer-table/InteractionPanel/TableOfContentsDropdown';
 import themeDecorator from '../themeDecorator';
 
-// Using the primitiveJson as a mock schema for demonstration purposes
-
-const schema: Schema = primitiveJson as Schema;
-
 const meta = {
 	component: TableOfContentsDropdown,
 	title: 'Viewer - Table/Table of Contents Dropdown',
@@ -20,12 +16,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Using the primitiveJson as a mock schema for demonstration purposes
+const schema: Schema = primitiveJson as Schema;
+
+// Mock functions for the story just to demonstrate interaction
+
+const onSchemaSelect = (schema: Schema) => {
+	console.log('Selected schema:', schema);
+};
+
+const onAccordionToggle = (schemaName: string, isOpen: boolean) => {
+	console.log(`Accordion ${isOpen ? 'opened' : 'closed'} for schema:`, schemaName);
+};
+
 export const Default: Story = {
 	args: {
 		schemas: [schema],
+		onSchemaSelect,
+		onAccordionToggle,
 	},
 };
 
 export const Empty: Story = {
-	args: { schemas: [] },
+	args: { schemas: [], onSchemaSelect, onAccordionToggle },
 };

--- a/samples/dictionary/advanced.json
+++ b/samples/dictionary/advanced.json
@@ -1,0 +1,35 @@
+{
+	"name": "Simple",
+	"version": "1.0",
+	"schemas": [
+		{
+			"name": "empty",
+			"description": "An empty schema with no fields.",
+			"fields": []
+		},
+		{
+			"name": "single_field",
+			"description": "A schema with a single field of type string.",
+			"fields": [{ "name": "single_string_field", "valueType": "string" }]
+		},
+		{
+			"name": "multiple_fields",
+			"description": "A schema with multiple fields of different types.",
+			"fields": [
+				{ "name": "string_field", "valueType": "string" },
+				{ "name": "integer_field", "valueType": "integer" },
+				{ "name": "boolean_field", "valueType": "boolean" }
+			]
+		},
+		{
+			"name": "primitives",
+			"description": "Includes one field of each primitive type without any restrictions. No Frills.",
+			"fields": [
+				{ "name": "boolean_field", "valueType": "boolean" },
+				{ "name": "integer_field", "valueType": "integer" },
+				{ "name": "number_field", "valueType": "number" },
+				{ "name": "string_field", "valueType": "string" }
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Implemented `TableOfContentDropdown` to wrap the existing `Dropdown`, open the matching accordion, and update the URL hash for automatic scrolling to the selected schema. Fixed existing styling issues with `Dropdown`

## Issues
- #270 

## Description of Changes


### UI

* Added a new component `TableOfContentsDropdown` which lists all schemas and handles selection.
  * Wraps the existing `Dropdown`, maps `schemas` to menu items, and on selection calls `onAccordionToggle` and sets `window.location.hash` so the matching accordion opens and the page scrolls to that schema’s table.
  * Included the `List` icon from theme/icons, following existing conventions, and passed it as the `leftIcon` prop.



## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
