### PR TITLE
feat: Add `createdAt` to `getDictionaries` list response

### DIFF
--- a/apps/server/src/config/swagger.json
+++ b/apps/server/src/config/swagger.json
@@ -516,20 +516,24 @@
 				"properties": {
 					"_id": {
 						"type": "string",
-						"description": "mongo generated object id"
+						"description": "Internal database ID."
 					},
 					"name": {
 						"type": "string",
-						"description": "The name of the parameter"
+						"description": "The name of the Dictionary."
 					},
 					"description": {
 						"type": "string",
-						"description": "Version of the dictionary",
+						"description": "Description of the Dictionary.",
 						"required": false
 					},
 					"version": {
 						"type": "string",
-						"description": "Version of the dictionary"
+						"description": "Version of the Dictionary."
+					},
+					"createdAt": {
+						"type": "string",
+						"description": "ISO formatted date that the Dictionary was created."
 					}
 				}
 			},

--- a/apps/server/src/db/dbTypes.ts
+++ b/apps/server/src/db/dbTypes.ts
@@ -34,6 +34,7 @@ export const DictionaryDocumentSummary = DictionaryDocument.pick({
 	name: true,
 	version: true,
 	description: true,
+	createdAt: true,
 	_id: true,
 });
 export type DictionaryDocumentSummary = zod.infer<typeof DictionaryDocumentSummary>;

--- a/apps/server/src/db/dictionary.ts
+++ b/apps/server/src/db/dictionary.ts
@@ -63,7 +63,7 @@ export const findByNameAndVersion = async (name: string, version: string): Promi
  * @returns
  */
 export const listAll = async (): Promise<DictionaryDocumentSummary[]> => {
-	return DictionaryModel.find({}, 'name version description').lean(true);
+	return DictionaryModel.find({}, 'name version description createdAt').lean(true);
 };
 
 /**

--- a/packages/client/docs/rest.md
+++ b/packages/client/docs/rest.md
@@ -30,21 +30,13 @@ List all dictionaries from Lectern Server. Optionally, a dictionary name can be 
 
 Returns an array with all Dictionaries that match the query. This is all dictionaries if no filters are provided, or the subset of dictionaries that match the provided dictionary name. Each entry in this array contains a subset of the dictionary fields.
 
-| Field       | Type   | Description                                                                                                                  |
-| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `_id`       | string | Internal ID for this dictionary. This is useful when requesting a dictionary by ID, for example with `rest.getDictionary()`. |
-| `name`      | string | Name of the dictionary.                                                                                                      |
-| `version`   | string | Version of the dictionary.                                                                                                   |
-| `createdAt` | Date   | When this version of the dictionary was created.                                                                             |
-
-```ts
-type DictionarySummary = {
-	_id: string,
-	name: string,
-	version: string,
-	createdAt: Date
-}
-```
+| Field         | Type                    | Description                                                                                                                  |
+| ------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `_id`         | `string`                | Internal ID for this dictionary. This is useful when requesting a dictionary by ID, for example with `rest.getDictionary()`. |
+| `name`        | `string`                | Name of the dictionary.                                                                                                      |
+| `description` | `string` \| `undefined` | Description of the dictionary. Optional property, could be `undefined`.                                                      |
+| `version`     | `string`                | Version of the dictionary.                                                                                                   |
+| `createdAt`   | `Date`                  | When this version of the dictionary was created.                                                                             |
 
 ```json
 [

--- a/packages/client/docs/rest.md
+++ b/packages/client/docs/rest.md
@@ -3,7 +3,7 @@
 The lectern client exports a set of functions to make requests to a Lectern Server REST API. This is exported in a property named `rest`.
 
 ```ts
-import * as lectern from '@overture-stack/lecter-client';
+import * as lectern from '@overture-stack/lectern-client';
 
 const dictionaryList = await lectern.rest.getDictionaries('http://lectern.example.com');
 ```
@@ -15,12 +15,12 @@ All functions in the REST API take the lectern host URL as the first argument, a
 | Function                              | Lectern Server REST API                                                          | Description                                                                                                     |
 | ------------------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | [listDictionaries](#listdictionaries) | `GET /dictionaries`                                                              | Fetch a list of all dictionaries available on the Lectern server.                                               |
-| [getDictionary](#getDictionary)       | `GET /dictionaries/{id}` <br/> `GET /dictionaries?name={name}&version={version}` | Fetch the contents of a single dictionary. This can be done by dictionary ID, or by dictonary name and version. |
+| [getDictionary](#getDictionary)       | `GET /dictionaries/{id}` <br/> `GET /dictionaries?name={name}&version={version}` | Fetch the contents of a single dictionary. This can be done by dictionary ID, or by dictionary name and version. |
 | [getDiff](#getDiff)                   | `GET /diff`                                                                      | Fetch the differences between two versions of the same dictionary.                                              |
 
 ### `listDictionaries()`
 
-List all dictionaries from Lectern Server. Optionally, the a dictionary name can be provided to filter the list to only dictionaries of the given name.
+List all dictionaries from Lectern Server. Optionally, a dictionary name can be provided to filter the list to only dictionaries of the given name.
 
 #### Options
 

--- a/packages/client/docs/rest.md
+++ b/packages/client/docs/rest.md
@@ -28,11 +28,21 @@ List all dictionaries from Lectern Server. Optionally, the a dictionary name can
 
 #### Returns
 
+Returns an array with all Dictionaries that match the query. This is all dictionaries if no filters are provided, or the subset of dictionaries that match the provided dictionary name. Each entry in this array contains a subset of the dictionary fields.
+
+| Field       | Type   | Description                                                                                                                  |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `_id`       | string | Internal ID for this dictionary. This is useful when requesting a dictionary by ID, for example with `rest.getDictionary()`. |
+| `name`      | string | Name of the dictionary.                                                                                                      |
+| `version`   | string | Version of the dictionary.                                                                                                   |
+| `createdAt` | Date   | When this version of the dictionary was created.                                                                             |
+
 ```ts
 type DictionarySummary = {
 	_id: string,
 	name: string,
-	version: string
+	version: string,
+	createdAt: Date
 }
 ```
 
@@ -41,17 +51,20 @@ type DictionarySummary = {
 	{
 		"_id": "678e62971a9a67cacd8f4325",
 		"name": "example_dictionary",
-		"version": "1.0"
+		"version": "1.0",
+		"createdAt": "2025-05-29T07:00:00.0000"
 	},
 	{
 		"_id": "678e63f91a9a67cacd8f4328",
 		"name": "example_dictionary",
-		"version": "1.1"
+		"version": "1.1",
+		"createdAt": "2025-05-30T215:00:00.0000",
 	},
 	{
 		"_id": "678e6bdd1a9a67cacd8f432d",
 		"name": "example_dictionary",
-		"version": "1.2"
+		"version": "1.2",
+		"createdAt": "2025-05-31T23:00:00.0000"
 	}
 ]
 ```

--- a/packages/client/src/rest/listDictionaries.ts
+++ b/packages/client/src/rest/listDictionaries.ts
@@ -26,6 +26,7 @@ const dictionarySummarySchema = zod.object({
 	_id: zod.string(),
 	name: zod.string(),
 	version: zod.string(),
+	createdAt: zod.coerce.date(),
 });
 export type DictionarySummary = zod.infer<typeof dictionarySummarySchema>;
 

--- a/packages/client/src/rest/listDictionaries.ts
+++ b/packages/client/src/rest/listDictionaries.ts
@@ -25,6 +25,7 @@ import formatAxiosError from './formatAxiosError';
 const dictionarySummarySchema = zod.object({
 	_id: zod.string(),
 	name: zod.string(),
+	description: zod.string().optional(),
 	version: zod.string(),
 	createdAt: zod.coerce.date(),
 });


### PR DESCRIPTION
## Summary

<!-- High level, short description of work done. 1-2 sentences. -->
Adds `createdAt` property to each DictionarySummary in the response from the Server's `getDictionaries` request.

The Client REST response is updated to expect this property, and it will coerce the String response into a JS Date object.


## Description of Changes
<!-- Describe the changes in your pull request **per service or package**, providing enough context for reviewers.

Be sure to call out any breaking changes, as well as any special instructions required to run the new code (i.e. New or updated dependencies? `pnpm i`. New migrations to run? `pnpm run migrate-dev`. etc.) 

Add a heading for each app/package that you have contributed changes to and list the changes included.
-->

### Server
- Add `createdAt` to `getDictionaries` endpoint
  - Update `DictionaryDocumentSummary` type to include `createdAt`
  - Update `DictionaryManager` to extract this property in the `listDictionaries` function

### Client
- Add `createdAt` to `rest.getDictionaries` response type, coerced to JS Date
- Updated Client REST documentation for `getDictionaries` response 

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
