### PR TITLE
#304: Include `createdAt` in rest client getDictionary response type

### DIFF
--- a/packages/client/src/rest/getDictionary.ts
+++ b/packages/client/src/rest/getDictionary.ts
@@ -22,14 +22,14 @@ import axios, { AxiosError } from 'axios';
 import { z as zod } from 'zod';
 import formatAxiosError from './formatAxiosError';
 
-const dictionaryRecordSchema = DictionaryBase.extend({
+const dictionaryServerRecordSchema = DictionaryBase.extend({
 	_id: zod.string(),
 	createdAt: zod.string(),
-	updatedAt: zod.string(),
 });
+export type DictionaryServerRecord = zod.infer<typeof dictionaryServerRecordSchema>;
 
-const getDictionaryByNameAndVersionResponseSchema = zod.tuple([dictionaryRecordSchema]);
-const getDictionaryByIdResponseSchema = dictionaryRecordSchema;
+const getDictionaryByNameAndVersionResponseSchema = zod.tuple([dictionaryServerRecordSchema]);
+const getDictionaryByIdResponseSchema = dictionaryServerRecordSchema;
 
 /**
  * Fetches a single Dictionary from a Lectern server. This can be done either by ID or by Name and Version.
@@ -47,7 +47,7 @@ export const getDictionary = async (
 	options?: {
 		showReferences?: boolean;
 	},
-): Promise<Result<Dictionary>> => {
+): Promise<Result<DictionaryServerRecord>> => {
 	const showReferences = options?.showReferences;
 	try {
 		if ('id' in dictionary) {


### PR DESCRIPTION
<!-- PR Title Should match format:
#{TicketNumber}: Description of Changes

if no ticket number, use `chore:`, `fix:`, `feat:` etc.

Example:
#123: Add pagination to List Applications endpoint
-->

## Summary
Fixes the return type of the REST client `getDictionary` function so that it includes the `_id` and `createdAt` information returned by the lectern server.

## Issues
- #304

## Description of Changes

### Client
- No runtime changes, implementation was already correct
- Updates the declared return type for `getDictionary` to include server properties `_id` and `createdAt`

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
