### PR TITLE
fix: rename `SchemaRestrictions` to `SchemaFieldRestrictions` and add `SchemaRestrictions` type to represent schema-level restrictions

### DIFF
--- a/packages/dictionary/src/metaSchema/dictionarySchemas.ts
+++ b/packages/dictionary/src/metaSchema/dictionarySchemas.ts
@@ -229,7 +229,7 @@ export const SchemaField = zod.discriminatedUnion('valueType', [
 ]);
 export type SchemaField = zod.infer<typeof SchemaField>;
 
-export type SchemaRestrictions = SchemaField['restrictions'];
+export type SchemaFieldRestrictions = SchemaField['restrictions'];
 
 /* ****** *
  * Schema *
@@ -296,6 +296,8 @@ export const Schema = zod
 		}
 	});
 export type Schema = zod.infer<typeof Schema>;
+
+export type SchemaRestrictions = Schema['restrictions'];
 
 /* ********** *
  * Dictionary *

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/AllowedValuesColumn/ComputeAllowedValues.ts
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/AllowedValuesColumn/ComputeAllowedValues.ts
@@ -20,7 +20,7 @@ import {
 	RestrictionCondition,
 	RestrictionRange,
 	SchemaField,
-	SchemaRestrictions,
+	SchemaFieldRestrictions,
 } from '@overture-stack/lectern-dictionary';
 import { CellContext } from '@tanstack/react-table';
 
@@ -41,7 +41,7 @@ export type AllowedValuesBaseDisplayItem = {
 };
 
 export type AllowedValuesColumnProps = {
-	restrictions: CellContext<SchemaField, SchemaRestrictions>;
+	restrictions: CellContext<SchemaField, SchemaFieldRestrictions>;
 };
 
 //Helper functions
@@ -173,7 +173,7 @@ const handleCodeList = (codeList: string | string[] | number[]): RestrictionItem
 };
 
 export const computeAllowedValuesColumn = (
-	restrictions: SchemaRestrictions,
+	restrictions: SchemaFieldRestrictions,
 	schemaField: SchemaField,
 ): AllowedValuesBaseDisplayItem => {
 	const allowedValuesBaseDisplayItem: AllowedValuesBaseDisplayItem = {};

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/AllowedValuesColumn/RenderAllowedValues.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/AllowedValuesColumn/RenderAllowedValues.tsx
@@ -19,11 +19,11 @@
 
 /** @jsxImportSource @emotion/react */
 
-import { SchemaField, SchemaRestrictions } from '@overture-stack/lectern-dictionary';
+import { SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 import FieldBlock from '../../../../../common/FieldBlock';
 import { computeAllowedValuesColumn } from './ComputeAllowedValues';
 
-export const renderAllowedValuesColumn = (restrictions: SchemaRestrictions, schemaField: SchemaField) => {
+export const renderAllowedValuesColumn = (restrictions: SchemaFieldRestrictions, schemaField: SchemaField) => {
 	const restrictionItems = computeAllowedValuesColumn(restrictions, schemaField);
 
 	if (Object.keys(restrictionItems).length === 0) {

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/Attribute.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/Attribute.tsx
@@ -20,7 +20,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { SchemaField, SchemaRestrictions } from '@overture-stack/lectern-dictionary';
+import { SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 
 import { Row } from '@tanstack/react-table';
 import Pill from '../../../../common/Pill';
@@ -37,14 +37,14 @@ const containerStyle = css`
 `;
 
 export const renderAttributesColumn = (tableRow: Row<SchemaField>) => {
-	const schemaRestrictions: SchemaRestrictions = tableRow.original.restrictions;
+	const schemaFieldRestrictions: SchemaFieldRestrictions = tableRow.original.restrictions;
 	const schemaField: SchemaField = tableRow.original;
 	const { unique } = schemaField;
 	return (
 		<div css={containerStyle}>
-			{schemaRestrictions && 'if' in schemaRestrictions ?
+			{schemaFieldRestrictions && 'if' in schemaFieldRestrictions ?
 				<OpenModalButton onClick={() => alert('Hello World')}>Required When</OpenModalButton>
-			:	<Pill>{schemaRestrictions && 'required' in schemaRestrictions ? 'Required' : 'Optional'}</Pill>}
+			:	<Pill>{schemaFieldRestrictions && 'required' in schemaFieldRestrictions ? 'Required' : 'Optional'}</Pill>}
 			{unique && <Pill>Unique</Pill>}
 		</div>
 	);

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/Fields.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/Fields.tsx
@@ -20,12 +20,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import {
-	DictionaryMeta,
-	type ForeignKeyRestriction,
-	SchemaField,
-	SchemaRestrictions,
-} from '@overture-stack/lectern-dictionary';
+import { DictionaryMeta, SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 import { Row } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 
@@ -124,7 +119,7 @@ export const FieldsColumn = ({ fieldRow }: FieldColumnProps) => {
 	const fieldDescription = fieldRow.original.description;
 	const fieldExamples = fieldRow.original.meta?.examples;
 
-	const fieldRestrictions: SchemaRestrictions = fieldRow.original.restrictions;
+	const fieldRestrictions: SchemaFieldRestrictions = fieldRow.original.restrictions;
 
 	// TODO: not sure why they are unknown types
 	const uniqueKey = fieldRestrictions && 'uniqueKey' in fieldRestrictions ? fieldRestrictions.uniqueKey : undefined;

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
@@ -21,7 +21,7 @@
 
 /** @jsxImportSource @emotion/react */
 
-import { SchemaField, SchemaRestrictions } from '@overture-stack/lectern-dictionary';
+import { SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 import { CellContext, createColumnHelper, Row } from '@tanstack/react-table';
 
 import { renderAllowedValuesColumn } from './Columns/AllowedValuesColumn/RenderAllowedValues';
@@ -58,9 +58,9 @@ export const getSchemaBaseColumns = () => [
 	columnHelper.accessor((row: SchemaField) => row.restrictions, {
 		id: 'allowedValues',
 		header: 'Allowed Values',
-		cell: (restrictions: CellContext<SchemaField, SchemaRestrictions>) => {
+		cell: (restrictions: CellContext<SchemaField, SchemaFieldRestrictions>) => {
 			const schemaField: SchemaField = restrictions.row.original;
-			const restrictionsValue: SchemaRestrictions = restrictions.getValue();
+			const restrictionsValue: SchemaFieldRestrictions = restrictions.getValue();
 			return renderAllowedValuesColumn(restrictionsValue, schemaField);
 		},
 	}),

--- a/packages/validation/src/validateField/restrictions/resolveFieldRestrictions.ts
+++ b/packages/validation/src/validateField/restrictions/resolveFieldRestrictions.ts
@@ -23,7 +23,7 @@ import {
 	type DataRecord,
 	type DataRecordValue,
 	type SchemaField,
-	type SchemaRestrictions,
+	type SchemaFieldRestrictions,
 } from '@overture-stack/lectern-dictionary';
 import type { FieldRestrictionRule } from '../FieldRestrictionRule';
 import { testConditionalRestriction } from '../conditions/testConditionalRestriction';
@@ -61,7 +61,7 @@ const extractRulesFromRestriction = (restrictions: AnyFieldRestrictions): FieldR
 };
 
 const recursiveResolveRestrictions = (
-	restrictions: SchemaRestrictions,
+	restrictions: SchemaFieldRestrictions,
 	value: DataRecordValue,
 	record: DataRecord,
 ): FieldRestrictionRule[] => {


### PR DESCRIPTION
## Summary

Refactored schema types to improve clarity and support schema-level restrictions.

## Description of Changes
- Renamed `SchemaRestrictions` to `SchemaFieldRestrictions` to better reflect the actual internal type.
- Exported a new `SchemaRestrictions` type to represent schema-level restrictions


## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
