### PR TITLE
Docs: Add documentation inside of storybook for testers

### DIFF
--- a/packages/ui/docs/README.md
+++ b/packages/ui/docs/README.md
@@ -1,10 +1,32 @@
 # Lectern UI - Developer Docs
 
-## Developer Quick Start and Storybook 
+## Developer Quick Start and Storybook
 
 The codebase contains a [Storybook](https://storybook.js.org/) development environment that can be used to explore and develop the components in this package.
 
 To run Storybook:
+
+0. Make sure you're in the Lectern UI directory (`packages/ui`)
+
+First, check your current directory:
+
+```sh
+pwd
+```
+
+If you're not already in the Lectern UI directory, navigate to it from the project root:
+
+```sh
+cd packages/ui
+```
+
+Verify you're now in the correct directory:
+
+```sh
+pwd
+```
+
+You should now see a path ending with `/lectern/packages/ui`
 
 1. Install all dependencies:
 
@@ -19,6 +41,28 @@ pnpm storybook
 ```
 
 Storybook will run on port 6006 by default: [http://localhost:6006/](http://localhost:6006/)
+
+# Testers
+
+Storybook allows users to change the properties being passed into components interactively, making it easy to test different configurations and see the results in real time.
+
+To explore and test components in Storybook:
+
+1. On the left-hand side of the Storybook interface, use the navigation panel to find the component you want to work with. For example, to view the Schema Table component, expand the "Viewer - Table" section and select "Schema Table".
+
+2. Once you've selected a component, you can interact with its different stories. Each story represents a different configuration or state of the component.
+
+3. Under each story type inside the "Docs" tab, you'll find a table that lists the props for the component. This table includes a "Control" column, which displays the current data being passed into the component. You can interact with these controls directly to modify the props and see the changes reflected in real time.
+
+4. Next to each prop in the table, there's an eye icon button labeled "Raw." Clicking this button lets you view the raw JSON object being passed to the component. You can interact with both the formatted and raw JSON, making changes as needed to test different configurations.
+
+5. The "Docs" tab also provides usage examples, prop tables, and additional information for the selected component, making it easy to review and understand how each component works.
+
+By using the prop table and the raw JSON controls in the Docs tab, you can quickly experiment with, test, and review the implementation details for any component in the Lectern UI library.
+
+# Developers
+
+This section contains information specifically for developers working with Lectern UI.
 
 ## Editing Stories
 
@@ -51,8 +95,8 @@ The theme selected from the toolbar theme selection tool will be applied to all 
 
 At the moment there is only one alternate theme provided. It is defined inside the `themeDecorator` file - to test alternate stylings please update this custom theme.
 
-
 #### Adding Additional Themes
+
 To add additional themes in the drop down for the `themeDecorator` to use, you must add an option for the storybook `globalType.theme` property. This is done in the [`../.storybook/preview.ts`](../.storybook/preview.ts) file:
 
 ```ts
@@ -71,7 +115,7 @@ const preview: Preview = {
 		},
 	},
 	// ...
-}
+};
 ```
 
 Now that we have an additional option, the `themeDecorator` must be provided the specified theme. The logic for providing the selected theme to the decorator is handled in the [`themeDecorator`](../stories/themeDecorator.tsx) file in the function `function getGlobalTheme(globalTheme: string)`. Add a new case for the `globalType.theme` value that you added to `./storybook/preview.ts`.
@@ -84,10 +128,10 @@ function getGlobalTheme(globalTheme: string): PartialTheme {
 		}
 		case 'newTheme': {
 			// Return your new theme
-			return { };
+			return {};
 		}
 		default: {
-				return {};
+			return {};
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Add Testers section to Lectern UI documentation with Storybook testing instructions. Ensured to be as specific as possible for a possible non technical users.

## Issues
- #324 

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
