### PR TITLE
feat: add optional field for the dictionaryController to support indi…

### DIFF
--- a/apps/server/src/config/swagger.json
+++ b/apps/server/src/config/swagger.json
@@ -355,6 +355,15 @@
 							"type": "string",
 							"enum": ["tsv", "csv"]
 						}
+					},
+					{
+						"name": "schemaName",
+						"in": "query",
+						"description": "Name of the schema to download",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {


### PR DESCRIPTION
## Summary

Implement individual schema downloading via the lectern server endpoints

## Issues
- #305 

## Description of Changes
Add an optional parameter where a user can specify a schema name, and it will individually download that schema. 
Apart of the requirements of #274 where a download can be initiated via the accordion
Add appropriate swagger documentation for the endpoint

### Server
- Update existing endpoint `GET /dictionaries/template/download` to allow for individual schema downloads


### Special Instructions
Before running these changes, you will need to ...



## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
