### PR TITLE
#420, #421, #422: Custom Schema Filtering Logic 

### DIFF
--- a/packages/ui/src/common/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/common/Accordion/AccordionItem.tsx
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the

--- a/packages/ui/src/common/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/common/Accordion/AccordionItem.tsx
@@ -111,7 +111,7 @@ const titleRowStyle = (theme: Theme) => css`
 	}
 `;
 
-const hashIconStyle = () => css`
+const hashIconStyle = css`
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -196,7 +196,7 @@ const AccordionItem = ({ index, accordionData, openState }: AccordionItemProps) 
 						<button
 							type="button"
 							data-anchor-button
-							css={hashIconStyle()}
+							css={hashIconStyle}
 							onClick={(event) => hashOnClick(event, windowLocationHash, setClipboardContents)}
 						>
 							<Hash width={24} height={24} fill={theme.colors.secondary} />

--- a/packages/ui/src/common/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/common/Dropdown/Dropdown.tsx
@@ -26,8 +26,6 @@ import { type MouseEvent as ReactMouseEvent, type ReactNode, useCallback, useEff
 
 import { type Theme, useThemeContext } from '../../theme/index';
 
-import DropDownItem from './DropdownItem';
-
 const disabledButtonStyle = css`
 	cursor: not-allowed;
 	opacity: 0.7;
@@ -94,41 +92,42 @@ const dropdownMenuStyle = (theme: Theme) => css`
 	z-index: 100;
 	max-height: 150px;
 	overflow-y: auto;
-	list-style: none;
 	margin: 0;
 	padding: 0;
 `;
 
-type MenuItem = {
-	label: string;
-	action: () => void;
-};
-
 export type DropDownProps = {
 	title?: string;
 	leftIcon?: ReactNode;
-	menuItems?: MenuItem[];
 	disabled?: boolean;
 	size?: number;
 	styles?: SerializedStyles;
 	children?: ReactNode;
-	panelStyles?: SerializedStyles;
+	closeOnSelect?: boolean;
 };
 
 /**
  * Dropdown component with toggle button and collapsible menu.
  *
- * @param {DropdownProps} props - Dropdown configuration
- * @param {DropDownProps} title - Text displayed on the dropdown button
- * @param {DropDownProps} leftIcon - Custom icon displayed on the left side
- * @param {DropDownProps} menuItems - Array of menu items with label and action
- * @param {DropDownProps} disabled - Whether the dropdown is disabled
- * @param {DropDownProps} size - Font size for title and icon dimensions in pixels
- * @param {DropDownProps} styles - Custom Emotion CSS styles to applied to the button
+ * @param {DropDownProps} props - Dropdown configuration
+ * @param {string} title - Text displayed on the dropdown button
+ * @param {ReactNode} leftIcon - Custom icon displayed on the left side
+ * @param {boolean} disabled - Whether the dropdown is disabled
+ * @param {number} size - Font size for title and icon dimensions in pixels
+ * @param {SerializedStyles} styles - Custom Emotion CSS styles applied to the button
+ * @param {ReactNode} children - Content rendered inside the dropdown panel
+ * @param {boolean} closeOnSelect - Whether clicking inside the panel closes the dropdown
  * @returns {JSX.Element} Dropdown component
  */
-
-const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16, styles, children, panelStyles }: DropDownProps) => {
+const Dropdown = ({
+	title,
+	leftIcon,
+	disabled = false,
+	size = 16,
+	styles,
+	children,
+	closeOnSelect = true,
+}: DropDownProps) => {
 	const [open, setOpen] = useState(false);
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const theme: Theme = useThemeContext();
@@ -159,14 +158,6 @@ const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16
 		[disabled],
 	);
 
-	const renderMenuItems = () => {
-		return menuItems.map(({ label, action }) => (
-			<DropDownItem key={label} action={action} onItemClick={() => setOpen(false)}>
-				{label}
-			</DropDownItem>
-		));
-	};
-
 	return (
 		<div ref={dropdownRef} css={parentStyle}>
 			<button
@@ -181,11 +172,9 @@ const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16
 				<ChevronDown fill={theme.colors?.accent_dark} width={size} height={size} />
 			</button>
 			{open && !disabled && (
-				children ?
-					<div css={[dropdownMenuStyle(theme), panelStyles]}>{children}</div>
-				:	<menu role="menu" css={[dropdownMenuStyle(theme), panelStyles]}>
-						{renderMenuItems()}
-					</menu>
+				<div css={dropdownMenuStyle(theme)} onClick={closeOnSelect ? () => setOpen(false) : undefined}>
+					{children}
+				</div>
 			)}
 		</div>
 	);

--- a/packages/ui/src/common/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/common/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -111,6 +111,8 @@ export type DropDownProps = {
 	disabled?: boolean;
 	size?: number;
 	styles?: SerializedStyles;
+	children?: ReactNode;
+	panelStyles?: SerializedStyles;
 };
 
 /**
@@ -126,7 +128,7 @@ export type DropDownProps = {
  * @returns {JSX.Element} Dropdown component
  */
 
-const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16, styles }: DropDownProps) => {
+const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16, styles, children, panelStyles }: DropDownProps) => {
 	const [open, setOpen] = useState(false);
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const theme: Theme = useThemeContext();
@@ -179,9 +181,11 @@ const Dropdown = ({ menuItems = [], title, leftIcon, disabled = false, size = 16
 				<ChevronDown fill={theme.colors?.accent_dark} width={size} height={size} />
 			</button>
 			{open && !disabled && (
-				<menu role="menu" css={dropdownMenuStyle(theme)}>
-					{renderMenuItems()}
-				</menu>
+				children ?
+					<div css={[dropdownMenuStyle(theme), panelStyles]}>{children}</div>
+				:	<menu role="menu" css={[dropdownMenuStyle(theme), panelStyles]}>
+						{renderMenuItems()}
+					</menu>
 			)}
 		</div>
 	);

--- a/packages/ui/src/common/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/common/Dropdown/Dropdown.tsx
@@ -90,7 +90,7 @@ const dropdownMenuStyle = (theme: Theme) => css`
 	border-radius: 9px;
 	box-sizing: border-box;
 	z-index: 100;
-	max-height: 150px;
+	max-height: 300px;
 	overflow-y: auto;
 	margin: 0;
 	padding: 0;

--- a/packages/ui/src/common/Dropdown/FilterRow.tsx
+++ b/packages/ui/src/common/Dropdown/FilterRow.tsx
@@ -23,9 +23,13 @@
 
 import { css } from '@emotion/react';
 
-import { useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../../theme/index';
-import type { CustomFilterCategory } from '../DictionaryTableViewer';
+
+export type FilterCategory = {
+	label: string;
+	filterProperty: string;
+	options: string[];
+};
 
 const sectionHeaderStyle = (theme: Theme) => css`
 	${theme.typography.buttonText};
@@ -39,6 +43,7 @@ const sectionHeaderStyle = (theme: Theme) => css`
 `;
 
 const categoryGroupStyle = css`
+	min-width: 200px;
 	&:first-of-type > div:first-of-type {
 		border-top: none;
 	}
@@ -65,40 +70,30 @@ const checkboxLabelStyle = (theme: Theme) => css`
 	user-select: none;
 `;
 
-export type FilterRowsProps = {
-	categories: CustomFilterCategory[];
+export type FilterRowProps = {
+	category: FilterCategory;
+	showHeader: boolean;
+	selections: string[];
+	onToggle: (option: string) => void;
 };
 
-const FilterRows = ({ categories }: FilterRowsProps) => {
+const FilterRow = ({ category, showHeader, selections, onToggle }: FilterRowProps) => {
 	const theme = useThemeContext();
-	const { customFilterSelections, toggleCustomFilter } = useDictionaryStateContext();
-	const hasMultipleCategories = categories.length > 1;
 
 	return (
-		<>
-			{categories.map((category) => {
-				const selected = customFilterSelections[category.filterProperty] ?? [];
+		<div css={categoryGroupStyle}>
+			{showHeader && <div css={sectionHeaderStyle(theme)}>{category.label} Filter</div>}
+			{category.options.map((option) => {
+				const isChecked = selections.includes(option);
 				return (
-					<div key={category.filterProperty} css={categoryGroupStyle}>
-						{hasMultipleCategories && <div css={sectionHeaderStyle(theme)}>{category.label} Filter</div>}
-						{category.options.map((option) => {
-							const isChecked = selected.includes(option);
-							return (
-								<label key={option} css={checkboxRowStyle(theme)}>
-									<input
-										type="checkbox"
-										checked={isChecked}
-										onChange={() => toggleCustomFilter(category.filterProperty, option)}
-									/>
-									<span css={checkboxLabelStyle(theme)}>{option}</span>
-								</label>
-							);
-						})}
-					</div>
+					<label key={option} css={checkboxRowStyle(theme)}>
+						<input type="checkbox" checked={isChecked} onChange={() => onToggle(option)} />
+						<span css={checkboxLabelStyle(theme)}>{option}</span>
+					</label>
 				);
 			})}
-		</>
+		</div>
 	);
 };
 
-export default FilterRows;
+export default FilterRow;

--- a/packages/ui/src/common/Dropdown/FilterRow.tsx
+++ b/packages/ui/src/common/Dropdown/FilterRow.tsx
@@ -33,9 +33,9 @@ export type FilterCategory = {
 
 const sectionHeaderStyle = (theme: Theme) => css`
 	${theme.typography.buttonText};
-	font-size: 13px;
+	font-size: 10px;
 	color: ${theme.colors.accent_dark};
-	padding: 6px 12px;
+	padding: 6px 8px;
 	border-top: 1px solid ${theme.colors.border_button};
 	border-bottom: 1px solid ${theme.colors.border_button};
 	text-transform: uppercase;
@@ -43,7 +43,6 @@ const sectionHeaderStyle = (theme: Theme) => css`
 `;
 
 const categoryGroupStyle = css`
-	min-width: 200px;
 	&:first-of-type > div:first-of-type {
 		border-top: none;
 	}
@@ -53,7 +52,7 @@ const checkboxRowStyle = (theme: Theme) => css`
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 4px 12px;
+	padding: 4px;
 	cursor: pointer;
 	&:hover {
 		background-color: ${theme.colors.accent_1};
@@ -65,6 +64,7 @@ const checkboxRowStyle = (theme: Theme) => css`
 
 const checkboxLabelStyle = (theme: Theme) => css`
 	${theme.typography.body};
+	font-size: 13px;
 	color: ${theme.colors.accent_dark};
 	cursor: pointer;
 	user-select: none;

--- a/packages/ui/src/common/Dropdown/index.ts
+++ b/packages/ui/src/common/Dropdown/index.ts
@@ -1,1 +1,2 @@
 export { default, type DropDownProps } from './Dropdown';
+export { default as FilterRow, type FilterRowProps, type FilterCategory } from './FilterRow';

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -39,7 +39,7 @@ export type DictionaryDataContextType = {
 
 export type FilterSelections = Record<string, string[]>;
 
-export type ActiveFilter = [string, string[]];
+export type ActiveFilter = [string, string[]][];
 
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -39,6 +39,8 @@ export type DictionaryDataContextType = {
 
 export type FilterSelections = Record<string, string[]>;
 
+export type ActiveFilter = [string, string[]];
+
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;
 	filters: FilterOptions[];

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -20,7 +20,7 @@
 
 import type { DictionaryServerRecord } from '@overture-stack/lectern-client/dist/rest';
 import type { Dictionary } from '@overture-stack/lectern-dictionary';
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
 import { sortDictionariesByVersion } from '../utils/sortDictionaries';
 import { fetchAndValidateHostedDictionaries, fetchRemoteDictionary } from './sources';
@@ -37,12 +37,17 @@ export type DictionaryDataContextType = {
 	errors: string[];
 };
 
+export type CustomFilterSelections = Record<string, string[]>;
+
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;
 	filters: FilterOptions[];
 	setCurrentDictionaryIndex: (index: number) => void;
 	setFilters: (filters: FilterOptions[]) => void;
 	selectedDictionary?: DictionaryServerUnion;
+	customFilterSelections: CustomFilterSelections;
+	toggleCustomFilter: (filterProperty: string, value: string) => void;
+	resetCustomFilters: () => void;
 };
 
 export type StaticDictionaryProviderProps = {
@@ -176,10 +181,27 @@ export type DictionaryStateProviderProps = {
 export const DictionaryStateProvider = ({ children }: DictionaryStateProviderProps) => {
 	const [currentDictionaryIndex, setCurrentDictionaryIndex] = useState(0);
 	const [filters, setFilters] = useState<FilterOptions[]>([]);
+	const [customFilterSelections, setCustomFilterSelections] = useState<CustomFilterSelections>({});
 
 	const dictionaryData = useDictionaryDataContext();
 	const { dictionaries } = dictionaryData;
 	const selectedDictionary = dictionaries?.[currentDictionaryIndex];
+
+	useEffect(() => {
+		setCustomFilterSelections({});
+	}, [currentDictionaryIndex]);
+
+	const toggleCustomFilter = useCallback((filterProperty: string, value: string) => {
+		setCustomFilterSelections((prev) => {
+			const current = prev[filterProperty] ?? [];
+			const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+			return { ...prev, [filterProperty]: next };
+		});
+	}, []);
+
+	const resetCustomFilters = useCallback(() => {
+		setCustomFilterSelections({});
+	}, []);
 
 	const value: DictionaryStateContextType = {
 		currentDictionaryIndex,
@@ -187,6 +209,9 @@ export const DictionaryStateProvider = ({ children }: DictionaryStateProviderPro
 		setCurrentDictionaryIndex,
 		setFilters,
 		selectedDictionary,
+		customFilterSelections,
+		toggleCustomFilter,
+		resetCustomFilters,
 	};
 
 	return <DictionaryStateContext.Provider value={value}>{children}</DictionaryStateContext.Provider>;

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -27,7 +27,7 @@ import { fetchAndValidateHostedDictionaries, fetchRemoteDictionary } from './sou
 
 export type DictionaryServerUnion = DictionaryServerRecord | Dictionary;
 
-export type FilterOptions = 'Required'[];
+export type FilterOptions = 'Required';
 
 export type DictionaryDataContextType = {
 	dictionaries?: DictionaryServerUnion[];
@@ -43,9 +43,9 @@ export type ActiveFilter = [string, string[]][];
 
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;
-	filters: FilterOptions;
+	filters: FilterOptions[];
 	setCurrentDictionaryIndex: (index: number) => void;
-	setFilters: (filters: FilterOptions) => void;
+	setFilters: (filters: FilterOptions[]) => void;
 	selectedDictionary?: DictionaryServerUnion;
 	filterSelections: FilterSelections;
 	toggleFilter: (filterProperty: string, value: string) => void;
@@ -182,7 +182,7 @@ export type DictionaryStateProviderProps = {
 
 export const DictionaryStateProvider = ({ children }: DictionaryStateProviderProps) => {
 	const [currentDictionaryIndex, setCurrentDictionaryIndex] = useState(0);
-	const [filters, setFilters] = useState<FilterOptions>(['Required']);
+	const [filters, setFilters] = useState<FilterOptions[]>(['Required']);
 	const [filterSelections, setFilterSelections] = useState<FilterSelections>({});
 
 	const dictionaryData = useDictionaryDataContext();

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -27,7 +27,7 @@ import { fetchAndValidateHostedDictionaries, fetchRemoteDictionary } from './sou
 
 export type DictionaryServerUnion = DictionaryServerRecord | Dictionary;
 
-export type FilterOptions = 'Required';
+export type FilterOptions = 'Required'[];
 
 export type DictionaryDataContextType = {
 	dictionaries?: DictionaryServerUnion[];
@@ -43,9 +43,9 @@ export type ActiveFilter = [string, string[]][];
 
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;
-	filters: FilterOptions[];
+	filters: FilterOptions;
 	setCurrentDictionaryIndex: (index: number) => void;
-	setFilters: (filters: FilterOptions[]) => void;
+	setFilters: (filters: FilterOptions) => void;
 	selectedDictionary?: DictionaryServerUnion;
 	filterSelections: FilterSelections;
 	toggleFilter: (filterProperty: string, value: string) => void;
@@ -182,7 +182,7 @@ export type DictionaryStateProviderProps = {
 
 export const DictionaryStateProvider = ({ children }: DictionaryStateProviderProps) => {
 	const [currentDictionaryIndex, setCurrentDictionaryIndex] = useState(0);
-	const [filters, setFilters] = useState<FilterOptions[]>([]);
+	const [filters, setFilters] = useState<FilterOptions>(['Required']);
 	const [filterSelections, setFilterSelections] = useState<FilterSelections>({});
 
 	const dictionaryData = useDictionaryDataContext();

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -27,7 +27,7 @@ import { fetchAndValidateHostedDictionaries, fetchRemoteDictionary } from './sou
 
 export type DictionaryServerUnion = DictionaryServerRecord | Dictionary;
 
-export type FilterOptions = 'Required' | 'All Fields';
+export type FilterOptions = 'Required';
 
 export type DictionaryDataContextType = {
 	dictionaries?: DictionaryServerUnion[];

--- a/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
+++ b/packages/ui/src/dictionary-controller/DictionaryDataContext.tsx
@@ -37,7 +37,7 @@ export type DictionaryDataContextType = {
 	errors: string[];
 };
 
-export type CustomFilterSelections = Record<string, string[]>;
+export type FilterSelections = Record<string, string[]>;
 
 export type DictionaryStateContextType = {
 	currentDictionaryIndex: number;
@@ -45,9 +45,9 @@ export type DictionaryStateContextType = {
 	setCurrentDictionaryIndex: (index: number) => void;
 	setFilters: (filters: FilterOptions[]) => void;
 	selectedDictionary?: DictionaryServerUnion;
-	customFilterSelections: CustomFilterSelections;
-	toggleCustomFilter: (filterProperty: string, value: string) => void;
-	resetCustomFilters: () => void;
+	filterSelections: FilterSelections;
+	toggleFilter: (filterProperty: string, value: string) => void;
+	resetFilters: () => void;
 };
 
 export type StaticDictionaryProviderProps = {
@@ -181,26 +181,26 @@ export type DictionaryStateProviderProps = {
 export const DictionaryStateProvider = ({ children }: DictionaryStateProviderProps) => {
 	const [currentDictionaryIndex, setCurrentDictionaryIndex] = useState(0);
 	const [filters, setFilters] = useState<FilterOptions[]>([]);
-	const [customFilterSelections, setCustomFilterSelections] = useState<CustomFilterSelections>({});
+	const [filterSelections, setFilterSelections] = useState<FilterSelections>({});
 
 	const dictionaryData = useDictionaryDataContext();
 	const { dictionaries } = dictionaryData;
 	const selectedDictionary = dictionaries?.[currentDictionaryIndex];
 
 	useEffect(() => {
-		setCustomFilterSelections({});
+		setFilterSelections({});
 	}, [currentDictionaryIndex]);
 
-	const toggleCustomFilter = useCallback((filterProperty: string, value: string) => {
-		setCustomFilterSelections((prev) => {
+	const toggleFilter = useCallback((filterProperty: string, value: string) => {
+		setFilterSelections((prev) => {
 			const current = prev[filterProperty] ?? [];
 			const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
 			return { ...prev, [filterProperty]: next };
 		});
 	}, []);
 
-	const resetCustomFilters = useCallback(() => {
-		setCustomFilterSelections({});
+	const resetFilters = useCallback(() => {
+		setFilterSelections({});
 	}, []);
 
 	const value: DictionaryStateContextType = {
@@ -209,9 +209,9 @@ export const DictionaryStateProvider = ({ children }: DictionaryStateProviderPro
 		setCurrentDictionaryIndex,
 		setFilters,
 		selectedDictionary,
-		customFilterSelections,
-		toggleCustomFilter,
-		resetCustomFilters,
+		filterSelections,
+		toggleFilter,
+		resetFilters,
 	};
 
 	return <DictionaryStateContext.Provider value={value}>{children}</DictionaryStateContext.Provider>;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -37,7 +37,7 @@ export {
 	type ToolbarProps,
 
 	// & individual parts for integrators to build their own
-	AttributeFilterDropdown,
+	AttributeFilterButton,
 	CollapseAllButton,
 	type CollapseAllButtonProps,
 	DictionaryDownloadButton,

--- a/packages/ui/src/theme/icons/CircleSlash.tsx
+++ b/packages/ui/src/theme/icons/CircleSlash.tsx
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+import IconProps from './IconProps';
+
+const CircleSlash = ({ fill, width, height, style }: IconProps) => {
+	return (
+		<svg
+			css={css`
+				${style}
+			`}
+			width={width || 91}
+			height={height || 91}
+			fill="none"
+			viewBox="0 0 91 91"
+		>
+			<path
+				d="M34.1252 56.875L56.8752 34.125M83.4168 45.5C83.4168 66.4408 66.441 83.4167 45.5002 83.4167C24.5594 83.4167 7.5835 66.4408 7.5835 45.5C7.5835 24.5592 24.5594 7.58334 45.5002 7.58334C66.441 7.58334 83.4168 24.5592 83.4168 45.5Z"
+				stroke={fill || '#9A9191'}
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+};
+
+export default CircleSlash;

--- a/packages/ui/src/theme/icons/Refresh.tsx
+++ b/packages/ui/src/theme/icons/Refresh.tsx
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+import IconProps from './IconProps';
+
+const Refresh = ({ fill, width, height, style }: IconProps) => {
+	return (
+		<svg
+			css={css`
+				${style}
+			`}
+			width={width || 12}
+			height={height || 12}
+			viewBox="0 0 14 14"
+			fill="none"
+		>
+			<path
+				d="M0.75 6.75001C0.75 7.93669 1.10189 9.09673 1.76118 10.0834C2.42047 11.0701 3.35754 11.8392 4.4539 12.2933C5.55026 12.7474 6.75665 12.8662 7.92054 12.6347C9.08443 12.4032 10.1535 11.8318 10.9926 10.9926C11.8318 10.1535 12.4032 9.08443 12.6347 7.92055C12.8662 6.75666 12.7474 5.55026 12.2933 4.45391C11.8391 3.35755 11.0701 2.42048 10.0834 1.76119C9.09672 1.1019 7.93669 0.750008 6.75 0.750008C5.07263 0.756318 3.46265 1.41082 2.25667 2.57667L0.75 4.08334M0.75 4.08334V0.750008M0.75 4.08334H4.08333"
+				stroke={fill || '#757575'}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+};
+
+export default Refresh;

--- a/packages/ui/src/theme/styles/icons.ts
+++ b/packages/ui/src/theme/styles/icons.ts
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the

--- a/packages/ui/src/theme/styles/icons.ts
+++ b/packages/ui/src/theme/styles/icons.ts
@@ -20,6 +20,7 @@
 
 import Cancel from '../icons/Cancel';
 import ChevronDown from '../icons/ChevronDown';
+import CircleSlash from '../icons/CircleSlash';
 import Collapse from '../icons/Collapse';
 import Eye from '../icons/Eye';
 import FileDownload from '../icons/FileDownload';
@@ -30,10 +31,12 @@ import ListFilter from '../icons/ListFilter';
 import MessageSquareWarning from '../icons/MessageSquareWarning';
 import Minus from '../icons/Minus';
 import Plus from '../icons/Plus';
+import Refresh from '../icons/Refresh';
 import Spinner from '../icons/Spinner';
 
 export default {
 	ChevronDown,
+	CircleSlash,
 	Spinner,
 	Collapse,
 	Eye,
@@ -46,4 +49,5 @@ export default {
 	Cancel,
 	Plus,
 	Minus,
+	Refresh,
 };

--- a/packages/ui/src/viewer-table/DictionaryHeader/DictionaryVersionSwitcher.tsx
+++ b/packages/ui/src/viewer-table/DictionaryHeader/DictionaryVersionSwitcher.tsx
@@ -18,9 +18,8 @@
  *
  */
 
-import { css } from '@emotion/react';
-
 import Dropdown from '../../common/Dropdown/index';
+import DropDownItem from '../../common/Dropdown/DropdownItem';
 import { useDictionaryDataContext, useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
 import History from '../../theme/icons/History';
 
@@ -55,13 +54,13 @@ const DictionaryVersionSwitcher = () => {
 
 	return (
 		displayVersionSwitcher && (
-			<Dropdown
-				menuItems={versionSwitcherObjectArray}
-				title={title}
-				leftIcon = {<History />}
-				disabled={loading || errors.length > 0}
-				size={16}
-			/>
+			<Dropdown title={title} leftIcon={<History />} disabled={loading || errors.length > 0} size={16}>
+				{versionSwitcherObjectArray.map(({ label, action }) => (
+					<DropDownItem key={label} action={action}>
+						{label}
+					</DropDownItem>
+				))}
+			</Dropdown>
 		)
 	);
 };

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -243,7 +243,7 @@ const DiagramModal = () => {
 const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTableViewerProps) => {
 	const theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
-	const { filters, selectedDictionary, customFilterSelections, resetCustomFilters } = useDictionaryStateContext();
+	const { filters, selectedDictionary, filterSelections, resetFilters } = useDictionaryStateContext();
 
 	const [isCollapsed, setIsCollapsed] = useState(false);
 	const [selectedSchemaIndex, setSelectedSchemaIndex] = useState<number | undefined>(undefined);
@@ -325,7 +325,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 	}, [handleHash]);
 
 	const activeFilters: [string, string[]][] = (customFilterDropdowns ?? []).flatMap((dropdown) => {
-		const values = customFilterSelections[dropdown.filterProperty];
+		const values = filterSelections[dropdown.filterProperty];
 
 		if (values === undefined || values.length === 0) {
 			return [];
@@ -411,7 +411,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 						<CircleSlash />
 						<div css={emptyFilterMessageStyle(theme)}>No schemas match the selected filters</div>
 						<div css={emptyFilterSubtextStyle(theme)}>Try adjusting or clearing your filter selections</div>
-						<button css={resetFilterButtonStyle(theme)} onClick={resetCustomFilters}>
+						<button css={resetFilterButtonStyle(theme)} onClick={resetFilters}>
 							<Refresh fill={theme.colors.grey_6} />
 							<p css={NoMarginParagraph}>Reset all filters</p>
 						</button>

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -29,7 +29,7 @@ import Accordion from '../common/Accordion/index';
 import type { FilterCategory } from '../common/Dropdown/index';
 import Modal from '../common/Modal';
 import { ErrorModal } from '../common/Error/ErrorModal';
-import { useDictionaryDataContext, useDictionaryStateContext } from '../dictionary-controller/DictionaryDataContext';
+import { type ActiveFilter, useDictionaryDataContext, useDictionaryStateContext } from '../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../theme/index';
 import { isFieldRequired } from '../utils/isFieldRequired';
 import { DiagramViewProvider, useDiagramViewContext } from './DiagramViewContext';
@@ -157,8 +157,8 @@ const isConditionalRestriction = (schemaFieldRestriction: SchemaFieldRestriction
 	return schemaFieldRestriction && 'if' in schemaFieldRestriction && schemaFieldRestriction.if !== undefined;
 };
 
-const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: [string, string[]][]): Schema | null => {
-	// Schema-level: hide entire schema if it doesn't match active custom filters
+const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: ActiveFilter[]): Schema | null => {
+	// Schema-level: hide entire schema if it doesn't match active filters
 	// Within a category: OR (schema matches any selected value)
 	// Across categories: AND (schema must match all categories)
 	if (activeFilters.length > 0) {
@@ -324,7 +324,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 		return () => window.removeEventListener('hashchange', handleHash);
 	}, [handleHash]);
 
-	const activeFilters: [string, string[]][] = (customFilterDropdowns ?? []).flatMap((dropdown) => {
+	const activeFilters: ActiveFilter[] = (filterDropdowns ?? []).flatMap((dropdown) => {
 		const values = filterSelections[dropdown.filterProperty];
 
 		if (values === undefined || values.length === 0) {

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -47,13 +47,13 @@ import DictionaryViewerLoadingPage from './DictionaryViewer/DictionaryViewerLoad
 import DiagramSubtitle from './Toolbar/DiagramSubtitle';
 import Toolbar from './Toolbar/index';
 
-export type CustomFilterDropdown = {
+export type FilterDropdown = {
 	label: string;
 	filterProperty: string;
 };
 
 export type DictionaryTableViewerProps = {
-	customFilterDropdowns?: CustomFilterDropdown[];
+	filterDropdowns?: FilterDropdown[];
 };
 
 const getByDotPath = (obj: unknown, path: string): unknown =>
@@ -240,7 +240,7 @@ const DiagramModal = () => {
 // TODO: produce a simplified version that accepts a dictionary and produces this same view,
 // so that there's no requirement for a Lectern server, etc. and without a Toolbar, or a simpler one.
 
-const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTableViewerProps) => {
+const DictionaryTableViewerContent = ({ filterDropdowns }: DictionaryTableViewerProps) => {
 	const theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
 	const { filters, selectedDictionary, filterSelections, resetFilters } = useDictionaryStateContext();
@@ -256,11 +256,11 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 	);
 
 	const filterCategories: FilterCategory[] | undefined = useMemo(() => {
-		if (!customFilterDropdowns?.length || !selectedDictionary?.schemas) {
+		if (!filterDropdowns?.length || !selectedDictionary?.schemas) {
 			return undefined;
 		}
 
-		const dropdownContexts = customFilterDropdowns.map((dropdown) => ({
+		const dropdownContexts = filterDropdowns.map((dropdown) => ({
 			dropdown,
 			set: new Set<string>(),
 		}));
@@ -286,7 +286,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 			filterProperty: dropdown.filterProperty,
 			options: Array.from(set),
 		}));
-	}, [customFilterDropdowns, selectedDictionary?.schemas]);
+	}, [filterDropdowns, selectedDictionary?.schemas]);
 
 	const handleHash = useCallback(() => {
 		const target = parseHash(window.location.hash, selectedDictionary?.schemas);
@@ -427,9 +427,9 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 	);
 };
 
-export const DictionaryTableViewer = ({ customFilterDropdowns }: DictionaryTableViewerProps) => (
+export const DictionaryTableViewer = ({ filterDropdowns }: DictionaryTableViewerProps) => (
 	<DiagramViewProvider>
-		<DictionaryTableViewerContent customFilterDropdowns={customFilterDropdowns} />
+		<DictionaryTableViewerContent filterDropdowns={filterDropdowns} />
 	</DiagramViewProvider>
 );
 

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -38,6 +38,7 @@ import {
 	RelationshipDiagramContent,
 	useActiveRelationship,
 } from './EntityRelationshipDiagram';
+import { NoMarginParagraph } from '../theme/emotion/index';
 
 import SchemaTable from './DataTable/SchemaTable/index';
 import DictionaryHeader from './DictionaryHeader/DictionaryHeader';
@@ -58,13 +59,6 @@ export type CustomFilterCategory = {
 
 export type DictionaryTableViewerProps = {
 	customFilterDropdowns?: CustomFilterDropdown[];
-};
-
-export type ToolbarCustomDropdown = {
-	label: string;
-	options: string[];
-	selectedValue: string | undefined;
-	onSelect: (value: string | undefined) => void;
 };
 
 const getByDotPath = (obj: unknown, path: string): unknown =>
@@ -122,20 +116,53 @@ const headerPanelBlockStyle = css`
 	gap: 0;
 `;
 
-const emptyFilterMessageStyle = (theme: Theme) => css`
-	${theme.typography.subtitle}
+const emptyFilterContainerStyle = css`
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	padding: 48px;
-	color: ${theme.colors.black};
+	padding: 100px 48px 0;
+	gap: 12px;
+`;
+
+const emptyFilterMessageStyle = (theme: Theme) => css`
+	${theme.typography.subtitleSecondary}
+	font-size: 28px;
+	color: ${theme.colors.grey_6};
+	text-align: center;
+`;
+
+const emptyFilterSubtextStyle = (theme: Theme) => css`
+	${theme.typography.body}
+	color: ${theme.colors.grey_6};
+	text-align: center;
+`;
+
+const resetFilterButtonStyle = (theme: Theme) => css`
+	${theme.typography.body}
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 16px;
+	line-height: 1;
+	margin-top: 8px;
+	padding: 6px 16px;
+	background-color: transparent;
+	color: ${theme.colors.grey_6};
+	border: 1px solid ${theme.colors.border_button};
+	border-radius: 9px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	&:hover {
+		background-color: ${theme.colors.accent_1};
+	}
 `;
 
 const isConditionalRestriction = (schemaFieldRestriction: SchemaFieldRestrictions) => {
 	return schemaFieldRestriction && 'if' in schemaFieldRestriction && schemaFieldRestriction.if !== undefined;
 };
 
-const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: [string, string][]): Schema | null => {
+const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: [string, string[]][]): Schema | null => {
 	// Schema-level: hide entire schema if it doesn't match active custom filters
 	// Within a category: OR (schema matches any selected value)
 	// Across categories: AND (schema must match all categories)
@@ -221,19 +248,19 @@ const DiagramModal = () => {
 const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTableViewerProps) => {
 	const theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
-	const { filters, selectedDictionary } = useDictionaryStateContext();
+	const { filters, selectedDictionary, customFilterSelections, resetCustomFilters } = useDictionaryStateContext();
 
 	const [isCollapsed, setIsCollapsed] = useState(false);
 	const [selectedSchemaIndex, setSelectedSchemaIndex] = useState<number | undefined>(undefined);
 	const [highlightedField, setHighlightedField] = useState<{ schemaName: string; fieldName: string } | null>(null);
-	const [customFilterSelections, setCustomFilterSelections] = useState<Record<string, string | undefined>>({});
+	const { CircleSlash, Refresh } = theme.icons;
 
 	const relationshipMap = useMemo(
 		() => (selectedDictionary ? buildRelationshipMap(selectedDictionary) : null),
 		[selectedDictionary],
 	);
 
-	const toolbarCustomDropdowns: ToolbarCustomDropdown[] | undefined = useMemo(() => {
+	const customFilterCategories: CustomFilterCategory[] | undefined = useMemo(() => {
 		if (!customFilterDropdowns?.length || !selectedDictionary?.schemas) {
 			return undefined;
 		}
@@ -263,9 +290,6 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 			label: dropdown.label,
 			filterProperty: dropdown.filterProperty,
 			options: Array.from(set),
-			selectedValue: customFilterSelections[dropdown.filterProperty],
-			onSelect: (value: string | undefined) =>
-				setCustomFilterSelections((prev) => ({ ...prev, [dropdown.filterProperty]: value })),
 		}));
 	}, [customFilterDropdowns, selectedDictionary?.schemas]);
 
@@ -388,7 +412,15 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 					customFilterCategories={customFilterCategories}
 				/>
 				{accordionItems.length === 0 && activeFilters.length > 0 ?
-					<div css={emptyFilterMessageStyle(theme)}>No schemas match the selected filter criteria.</div>
+					<div css={emptyFilterContainerStyle}>
+						<CircleSlash />
+						<div css={emptyFilterMessageStyle(theme)}>No schemas match the selected filters</div>
+						<div css={emptyFilterSubtextStyle(theme)}>Try adjusting or clearing your filter selections</div>
+						<button css={resetFilterButtonStyle(theme)} onClick={resetCustomFilters}>
+							<Refresh fill={theme.colors.grey_6} />
+							<p css={NoMarginParagraph}>Reset all filters</p>
+						</button>
+					</div>
 				:	<Accordion accordionItems={accordionItems} collapseAll={isCollapsed} selectedIndex={selectedSchemaIndex} />}
 			</div>
 			{relationshipMap && !loading && errors.length === 0 && (

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -157,7 +157,7 @@ const isConditionalRestriction = (schemaFieldRestriction: SchemaFieldRestriction
 	return schemaFieldRestriction && 'if' in schemaFieldRestriction && schemaFieldRestriction.if !== undefined;
 };
 
-const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: ActiveFilter[]): Schema | null => {
+const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: ActiveFilter): Schema | null => {
 	// Schema-level: hide entire schema if it doesn't match active filters
 	// Within a category: OR (schema matches any selected value)
 	// Across categories: AND (schema must match all categories)
@@ -324,7 +324,7 @@ const DictionaryTableViewerContent = ({ filterDropdowns }: DictionaryTableViewer
 		return () => window.removeEventListener('hashchange', handleHash);
 	}, [handleHash]);
 
-	const activeFilters: ActiveFilter[] = (filterDropdowns ?? []).flatMap((dropdown) => {
+	const activeFilters: ActiveFilter = (filterDropdowns ?? []).flatMap((dropdown) => {
 		const values = filterSelections[dropdown.filterProperty];
 
 		if (values === undefined || values.length === 0) {

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -26,6 +26,7 @@ import type { Dictionary, Schema, SchemaFieldRestrictions } from '@overture-stac
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Accordion from '../common/Accordion/index';
+import type { FilterCategory } from '../common/Dropdown/index';
 import Modal from '../common/Modal';
 import { ErrorModal } from '../common/Error/ErrorModal';
 import { useDictionaryDataContext, useDictionaryStateContext } from '../dictionary-controller/DictionaryDataContext';
@@ -49,12 +50,6 @@ import Toolbar from './Toolbar/index';
 export type CustomFilterDropdown = {
 	label: string;
 	filterProperty: string;
-};
-
-export type CustomFilterCategory = {
-	label: string;
-	filterProperty: string;
-	options: string[];
 };
 
 export type DictionaryTableViewerProps = {
@@ -260,7 +255,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 		[selectedDictionary],
 	);
 
-	const customFilterCategories: CustomFilterCategory[] | undefined = useMemo(() => {
+	const filterCategories: FilterCategory[] | undefined = useMemo(() => {
 		if (!customFilterDropdowns?.length || !selectedDictionary?.schemas) {
 			return undefined;
 		}
@@ -409,7 +404,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 					onSelect={handleAccordionSelect}
 					setIsCollapsed={setIsCollapsed}
 					isCollapsed={isCollapsed}
-					customFilterCategories={customFilterCategories}
+					filterCategories={filterCategories}
 				/>
 				{accordionItems.length === 0 && activeFilters.length > 0 ?
 					<div css={emptyFilterContainerStyle}>

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -50,6 +50,12 @@ export type CustomFilterDropdown = {
 	filterProperty: string;
 };
 
+export type CustomFilterCategory = {
+	label: string;
+	filterProperty: string;
+	options: string[];
+};
+
 export type DictionaryTableViewerProps = {
 	customFilterDropdowns?: CustomFilterDropdown[];
 };
@@ -131,8 +137,10 @@ const isConditionalRestriction = (schemaFieldRestriction: SchemaFieldRestriction
 
 const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: [string, string][]): Schema | null => {
 	// Schema-level: hide entire schema if it doesn't match active custom filters
+	// Within a category: OR (schema matches any selected value)
+	// Across categories: AND (schema must match all categories)
 	if (activeFilters.length > 0) {
-		const matches = activeFilters.every(([filterProperty, value]) => {
+		const matches = activeFilters.every(([filterProperty, values]) => {
 			const metaValue = getByDotPath(schema, filterProperty);
 
 			if (metaValue == null) {
@@ -140,10 +148,10 @@ const getFilteredSchema = (schema: Schema, filters: string[], activeFilters: [st
 			}
 
 			if (Array.isArray(metaValue)) {
-				return metaValue.some((v) => String(v) === value);
+				return metaValue.some((v) => values.includes(String(v)));
 			}
 
-			return String(metaValue) === value;
+			return values.includes(String(metaValue));
 		});
 
 		if (!matches) {
@@ -253,12 +261,13 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 
 		return dropdownContexts.map(({ dropdown, set }) => ({
 			label: dropdown.label,
+			filterProperty: dropdown.filterProperty,
 			options: Array.from(set),
 			selectedValue: customFilterSelections[dropdown.filterProperty],
 			onSelect: (value: string | undefined) =>
 				setCustomFilterSelections((prev) => ({ ...prev, [dropdown.filterProperty]: value })),
 		}));
-	}, [customFilterDropdowns, selectedDictionary?.schemas, customFilterSelections]);
+	}, [customFilterDropdowns, selectedDictionary?.schemas]);
 
 	const handleHash = useCallback(() => {
 		const target = parseHash(window.location.hash, selectedDictionary?.schemas);
@@ -296,14 +305,14 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 		return () => window.removeEventListener('hashchange', handleHash);
 	}, [handleHash]);
 
-	const activeFilters: [string, string][] = (customFilterDropdowns ?? []).flatMap((dropdown) => {
-		const value = customFilterSelections[dropdown.filterProperty];
+	const activeFilters: [string, string[]][] = (customFilterDropdowns ?? []).flatMap((dropdown) => {
+		const values = customFilterSelections[dropdown.filterProperty];
 
-		if (value === undefined) {
+		if (values === undefined || values.length === 0) {
 			return [];
 		}
 
-		return [[dropdown.filterProperty, value]];
+		return [[dropdown.filterProperty, values]];
 	});
 
 	const accordionItems = useMemo(() => {
@@ -376,7 +385,7 @@ const DictionaryTableViewerContent = ({ customFilterDropdowns }: DictionaryTable
 					onSelect={handleAccordionSelect}
 					setIsCollapsed={setIsCollapsed}
 					isCollapsed={isCollapsed}
-					customFilterDropdowns={toolbarCustomDropdowns}
+					customFilterCategories={customFilterCategories}
 				/>
 				{accordionItems.length === 0 && activeFilters.length > 0 ?
 					<div css={emptyFilterMessageStyle(theme)}>No schemas match the selected filter criteria.</div>

--- a/packages/ui/src/viewer-table/DictionaryViewerPage.tsx
+++ b/packages/ui/src/viewer-table/DictionaryViewerPage.tsx
@@ -21,23 +21,23 @@
 import { DictionaryLecternDataProvider, DictionaryStateProvider } from '../dictionary-controller/DictionaryDataContext';
 
 import DictionaryTableViewer from './DictionaryTableViewer';
-import type { CustomFilterDropdown } from './DictionaryTableViewer';
+import type { FilterDropdown } from './DictionaryTableViewer';
 
 export type DictionaryTableProps = {
 	lecternUrl: string;
 	dictionaryName: string;
-	customFilterDropdowns?: CustomFilterDropdown[];
+	filterDropdowns?: FilterDropdown[];
 };
 
 /**
  * DictionaryViewerPage component.
  * @param {DictionaryTableProps} props
  */
-const DictionaryViewerPage = ({ lecternUrl, dictionaryName, customFilterDropdowns }: DictionaryTableProps) => {
+const DictionaryViewerPage = ({ lecternUrl, dictionaryName, filterDropdowns }: DictionaryTableProps) => {
 	return (
 		<DictionaryLecternDataProvider lecternUrl={lecternUrl} dictionaryName={dictionaryName}>
 			<DictionaryStateProvider>
-				<DictionaryTableViewer customFilterDropdowns={customFilterDropdowns} />
+				<DictionaryTableViewer filterDropdowns={filterDropdowns} />
 			</DictionaryStateProvider>
 		</DictionaryLecternDataProvider>
 	);

--- a/packages/ui/src/viewer-table/Toolbar/AttributeFilterButton.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/AttributeFilterButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -17,15 +17,11 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Dropdown from '../../common/Dropdown/index';
-import {
-	FilterOptions,
-	useDictionaryDataContext,
-	useDictionaryStateContext,
-} from '../../dictionary-controller/DictionaryDataContext';
+import Button from '../../common/Button';
+import { useDictionaryDataContext, useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../../theme/index';
 
-const AttributeFilterDropdown = () => {
+const AttributeFilterButton = () => {
 	const theme: Theme = useThemeContext();
 
 	const { loading, errors } = useDictionaryDataContext();
@@ -33,33 +29,21 @@ const AttributeFilterDropdown = () => {
 
 	const { ListFilter } = theme.icons;
 
-	const handleFilterSelect = (selectedFilterName: FilterOptions) => {
-		if (filters?.includes(selectedFilterName)) {
-			setFilters([]);
-			return;
-		}
-		setFilters([selectedFilterName]);
+	const isRequired = filters.includes('Required');
+
+	const handleClick = () => {
+		setFilters(isRequired ? [] : ['Required']);
 	};
 
-	const menuItems = [
-		{
-			label: 'Required',
-			action: () => handleFilterSelect('Required'),
-		},
-		{
-			label: 'All Fields',
-			action: () => handleFilterSelect('All Fields'),
-		},
-	];
-
 	return (
-		<Dropdown
-			leftIcon={<ListFilter />}
-			title="Filters"
-			menuItems={menuItems}
-			disabled={errors.length > 0 || loading}
-		/>
+		<Button
+			icon={<ListFilter fill={theme.colors.accent_dark} />}
+			onClick={handleClick}
+			disabled={loading || errors.length > 0}
+		>
+			{isRequired ? 'By Required' : 'Show Required'}
+		</Button>
 	);
 };
 
-export default AttributeFilterDropdown;
+export default AttributeFilterButton;

--- a/packages/ui/src/viewer-table/Toolbar/FilterRows.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/FilterRows.tsx
@@ -1,0 +1,105 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+import { useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
+import { type Theme, useThemeContext } from '../../theme/index';
+import type { CustomFilterCategory } from '../DictionaryTableViewer';
+
+const sectionHeaderStyle = (theme: Theme) => css`
+	${theme.typography.buttonText};
+	font-size: 13px;
+	color: ${theme.colors.accent_dark};
+	padding: 6px 12px;
+	border-top: 1px solid ${theme.colors.border_button};
+	border-bottom: 1px solid ${theme.colors.border_button};
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+`;
+
+const categoryGroupStyle = css`
+	&:first-of-type > div:first-of-type {
+		border-top: none;
+	}
+`;
+
+const checkboxRowStyle = (theme: Theme) => css`
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 12px;
+	cursor: pointer;
+	&:hover {
+		background-color: ${theme.colors.accent_1};
+	}
+	input[type='checkbox'] {
+		accent-color: #3a8736;
+	}
+`;
+
+const checkboxLabelStyle = (theme: Theme) => css`
+	${theme.typography.body};
+	color: ${theme.colors.accent_dark};
+	cursor: pointer;
+	user-select: none;
+`;
+
+export type FilterRowsProps = {
+	categories: CustomFilterCategory[];
+};
+
+const FilterRows = ({ categories }: FilterRowsProps) => {
+	const theme = useThemeContext();
+	const { customFilterSelections, toggleCustomFilter } = useDictionaryStateContext();
+
+	const hasMultipleCategories = categories.length > 1;
+
+	return (
+		<>
+			{categories.map((category) => {
+				const selected = customFilterSelections[category.filterProperty] ?? [];
+				return (
+					<div key={category.filterProperty} css={categoryGroupStyle}>
+						{hasMultipleCategories && <div css={sectionHeaderStyle(theme)}>{category.label} Filter</div>}
+						{category.options.map((option) => {
+							const isChecked = selected.includes(option);
+							return (
+								<label key={option} css={checkboxRowStyle(theme)}>
+									<input
+										type="checkbox"
+										checked={isChecked}
+										onChange={() => toggleCustomFilter(category.filterProperty, option)}
+									/>
+									<span css={checkboxLabelStyle(theme)}>{option}</span>
+								</label>
+							);
+						})}
+					</div>
+				);
+			})}
+		</>
+	);
+};
+
+export default FilterRows;

--- a/packages/ui/src/viewer-table/Toolbar/FilterRows.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/FilterRows.tsx
@@ -72,7 +72,6 @@ export type FilterRowsProps = {
 const FilterRows = ({ categories }: FilterRowsProps) => {
 	const theme = useThemeContext();
 	const { customFilterSelections, toggleCustomFilter } = useDictionaryStateContext();
-
 	const hasMultipleCategories = categories.length > 1;
 
 	return (

--- a/packages/ui/src/viewer-table/Toolbar/TableOfContentsDropdown.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/TableOfContentsDropdown.tsx
@@ -22,6 +22,7 @@
 import type { Schema } from '@overture-stack/lectern-dictionary';
 
 import Dropdown from '../../common/Dropdown/index';
+import DropDownItem from '../../common/Dropdown/DropdownItem';
 import { useDictionaryDataContext } from '../../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../../theme/index';
 
@@ -41,12 +42,13 @@ const TableOfContentsDropdown = ({ schemas, onSelect }: TableOfContentsDropdownP
 	}));
 
 	return schemas.length > 0 ?
-			<Dropdown
-				leftIcon={<List />}
-				title="Table of Contents"
-				menuItems={menuItemsFromSchemas}
-				disabled={loading || errors.length > 0}
-			/>
+			<Dropdown leftIcon={<List />} title="Table of Contents" disabled={loading || errors.length > 0}>
+				{menuItemsFromSchemas.map(({ label, action }) => (
+					<DropDownItem key={label} action={action}>
+						{label}
+					</DropDownItem>
+				))}
+			</Dropdown>
 		:	null;
 };
 

--- a/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
@@ -26,10 +26,11 @@ import { css } from '@emotion/react';
 import { useDictionaryDataContext, useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../../theme/index';
 import { ToolbarSkeleton } from '../Loading';
+import type { CustomFilterCategory } from '../DictionaryTableViewer';
 
 import Dropdown from '../../common/Dropdown/index';
-import type { ToolbarCustomDropdown } from '../DictionaryTableViewer';
-import AttributeFilterDropdown from './AttributeFilterDropdown';
+import AttributeFilterButton from './AttributeFilterButton';
+import FilterRows from './FilterRows';
 import CollapseAllButton from './CollapseAllButton';
 import DiagramViewButton from './DiagramViewButton';
 import DictionaryDownloadButton from './DictionaryDownloadButton';
@@ -40,7 +41,7 @@ export type ToolbarProps = {
 	onSelect: (schemaNameIndex: number) => void;
 	setIsCollapsed: (collapsed: boolean) => void;
 	isCollapsed: boolean;
-	customFilterDropdowns?: ToolbarCustomDropdown[];
+	customFilterCategories?: CustomFilterCategory[];
 };
 
 const panelStyles = (theme: Theme) => css`
@@ -64,9 +65,14 @@ const sectionStyles = css`
 	gap: 16px;
 `;
 
-const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterDropdowns }: ToolbarProps) => {
+const customFilterPanelStyles = css`
+	min-width: 200px;
+	max-height: 300px;
+`;
+
+const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterCategories }: ToolbarProps) => {
 	const theme: Theme = useThemeContext();
-	const { loading } = useDictionaryDataContext();
+	const { loading, errors } = useDictionaryDataContext();
 	const { selectedDictionary } = useDictionaryStateContext();
 
 	if (!selectedDictionary && !loading) {
@@ -82,20 +88,6 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterDropdowns 
 			<div css={sectionStyles}>
 				<TableOfContentsDropdown schemas={selectedDictionary?.schemas ?? []} onSelect={onSelect} />
 				<DiagramViewButton />
-				{customFilterDropdowns &&
-					customFilterDropdowns.map((dropdown) => (
-						<Dropdown
-							key={dropdown.label}
-							title={dropdown.selectedValue ?? dropdown.label}
-							menuItems={[
-								{ label: 'All', action: () => dropdown.onSelect(undefined) },
-								...dropdown.options.map((option) => ({
-									label: option,
-									action: () => dropdown.onSelect(option),
-								})),
-							]}
-						/>
-					))}
 				{isCollapsed ?
 					<ExpandAllButton onClick={() => setIsCollapsed(false)} />
 				:	<CollapseAllButton onClick={() => setIsCollapsed(true)} />}

--- a/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
@@ -74,6 +74,7 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterCategories
 	const theme: Theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
 	const { selectedDictionary } = useDictionaryStateContext();
+	const { ListFilter } = theme.icons;
 
 	if (!selectedDictionary && !loading) {
 		return null;
@@ -94,7 +95,7 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterCategories
 				<AttributeFilterButton />
 				{customFilterCategories && customFilterCategories.length > 0 && (
 					<Dropdown
-						leftIcon={<theme.icons.ListFilter />}
+						leftIcon={<ListFilter />}
 						title={customFilterCategories.length === 1 ? customFilterCategories[0].label : 'Filters'}
 						disabled={loading || errors.length > 0}
 						panelStyles={customFilterPanelStyles}

--- a/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
@@ -65,7 +65,7 @@ const sectionStyles = css`
 const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, filterCategories }: ToolbarProps) => {
 	const theme: Theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
-	const { selectedDictionary, customFilterSelections, toggleCustomFilter } = useDictionaryStateContext();
+	const { selectedDictionary, filterSelections, toggleFilter } = useDictionaryStateContext();
 	const { ListFilter } = theme.icons;
 
 	if (!selectedDictionary && !loading) {
@@ -97,8 +97,8 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, filterCategories }: To
 								key={category.filterProperty}
 								category={category}
 								showHeader={filterCategories.length > 1}
-								selections={customFilterSelections[category.filterProperty] ?? []}
-								onToggle={(option) => toggleCustomFilter(category.filterProperty, option)}
+								selections={filterSelections[category.filterProperty] ?? []}
+								onToggle={(option) => toggleFilter(category.filterProperty, option)}
 							/>
 						))}
 					</Dropdown>

--- a/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
@@ -26,11 +26,8 @@ import { css } from '@emotion/react';
 import { useDictionaryDataContext, useDictionaryStateContext } from '../../dictionary-controller/DictionaryDataContext';
 import { type Theme, useThemeContext } from '../../theme/index';
 import { ToolbarSkeleton } from '../Loading';
-import type { CustomFilterCategory } from '../DictionaryTableViewer';
-
-import Dropdown from '../../common/Dropdown/index';
+import Dropdown, { FilterRow, type FilterCategory } from '../../common/Dropdown/index';
 import AttributeFilterButton from './AttributeFilterButton';
-import FilterRows from './FilterRows';
 import CollapseAllButton from './CollapseAllButton';
 import DiagramViewButton from './DiagramViewButton';
 import DictionaryDownloadButton from './DictionaryDownloadButton';
@@ -41,7 +38,7 @@ export type ToolbarProps = {
 	onSelect: (schemaNameIndex: number) => void;
 	setIsCollapsed: (collapsed: boolean) => void;
 	isCollapsed: boolean;
-	customFilterCategories?: CustomFilterCategory[];
+	filterCategories?: FilterCategory[];
 };
 
 const panelStyles = (theme: Theme) => css`
@@ -65,15 +62,10 @@ const sectionStyles = css`
 	gap: 16px;
 `;
 
-const customFilterPanelStyles = css`
-	min-width: 200px;
-	max-height: 300px;
-`;
-
-const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterCategories }: ToolbarProps) => {
+const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, filterCategories }: ToolbarProps) => {
 	const theme: Theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
-	const { selectedDictionary } = useDictionaryStateContext();
+	const { selectedDictionary, customFilterSelections, toggleCustomFilter } = useDictionaryStateContext();
 	const { ListFilter } = theme.icons;
 
 	if (!selectedDictionary && !loading) {
@@ -93,14 +85,22 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterCategories
 					<ExpandAllButton onClick={() => setIsCollapsed(false)} />
 				:	<CollapseAllButton onClick={() => setIsCollapsed(true)} />}
 				<AttributeFilterButton />
-				{customFilterCategories && customFilterCategories.length > 0 && (
+				{filterCategories && filterCategories.length > 0 && (
 					<Dropdown
 						leftIcon={<ListFilter />}
-						title={customFilterCategories.length === 1 ? customFilterCategories[0].label : 'Filters'}
+						title={filterCategories.length === 1 ? filterCategories[0].label : 'Filters'}
 						disabled={loading || errors.length > 0}
-						panelStyles={customFilterPanelStyles}
+						closeOnSelect={false}
 					>
-						<FilterRows categories={customFilterCategories} />
+						{filterCategories.map((category) => (
+							<FilterRow
+								key={category.filterProperty}
+								category={category}
+								showHeader={filterCategories.length > 1}
+								selections={customFilterSelections[category.filterProperty] ?? []}
+								onToggle={(option) => toggleCustomFilter(category.filterProperty, option)}
+							/>
+						))}
 					</Dropdown>
 				)}
 			</div>

--- a/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/viewer-table/Toolbar/Toolbar.tsx
@@ -99,7 +99,17 @@ const Toolbar = ({ onSelect, setIsCollapsed, isCollapsed, customFilterDropdowns 
 				{isCollapsed ?
 					<ExpandAllButton onClick={() => setIsCollapsed(false)} />
 				:	<CollapseAllButton onClick={() => setIsCollapsed(true)} />}
-				<AttributeFilterDropdown />
+				<AttributeFilterButton />
+				{customFilterCategories && customFilterCategories.length > 0 && (
+					<Dropdown
+						leftIcon={<theme.icons.ListFilter />}
+						title={customFilterCategories.length === 1 ? customFilterCategories[0].label : 'Filters'}
+						disabled={loading || errors.length > 0}
+						panelStyles={customFilterPanelStyles}
+					>
+						<FilterRows categories={customFilterCategories} />
+					</Dropdown>
+				)}
 			</div>
 			<div css={sectionStyles}>
 				<DictionaryDownloadButton fileType="tsv" />

--- a/packages/ui/src/viewer-table/Toolbar/index.ts
+++ b/packages/ui/src/viewer-table/Toolbar/index.ts
@@ -1,5 +1,4 @@
 export { default as AttributeFilterButton } from './AttributeFilterButton.js';
-export { default as FilterRows, type FilterRowsProps } from './FilterRows.js';
 export { default as CollapseAllButton, type CollapseAllButtonProps } from './CollapseAllButton.js';
 export { default as DiagramViewButton } from './DiagramViewButton.js';
 export { default as DictionaryDownloadButton, type DictionaryDownloadButtonProps } from './DictionaryDownloadButton.js';

--- a/packages/ui/src/viewer-table/Toolbar/index.ts
+++ b/packages/ui/src/viewer-table/Toolbar/index.ts
@@ -1,4 +1,5 @@
-export { default as AttributeFilterDropdown } from './AttributeFilterDropdown.js';
+export { default as AttributeFilterButton } from './AttributeFilterButton.js';
+export { default as FilterRows, type FilterRowsProps } from './FilterRows.js';
 export { default as CollapseAllButton, type CollapseAllButtonProps } from './CollapseAllButton.js';
 export { default as DiagramViewButton } from './DiagramViewButton.js';
 export { default as DictionaryDownloadButton, type DictionaryDownloadButtonProps } from './DictionaryDownloadButton.js';

--- a/packages/ui/src/viewer-table/index.ts
+++ b/packages/ui/src/viewer-table/index.ts
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the

--- a/packages/ui/src/viewer-table/index.ts
+++ b/packages/ui/src/viewer-table/index.ts
@@ -27,7 +27,7 @@ export {
 	type ToolbarProps,
 
 	// individual parts for integrators to build their own
-	AttributeFilterDropdown,
+	AttributeFilterButton,
 	CollapseAllButton,
 	type CollapseAllButtonProps,
 	DictionaryDownloadButton,

--- a/packages/ui/src/viewer-table/index.ts
+++ b/packages/ui/src/viewer-table/index.ts
@@ -40,4 +40,5 @@ export {
 
 // TODO: study which of the following are worth exporting at root, if any
 export * from './DictionaryTableViewer';
+export { type FilterCategory } from '../common/Dropdown/index';
 export * from './Loading';

--- a/packages/ui/stories/common/DropDown.stories.tsx
+++ b/packages/ui/stories/common/DropDown.stories.tsx
@@ -24,6 +24,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Dropdown from '../../src/common/Dropdown/index';
+import DropDownItem from '../../src/common/Dropdown/DropdownItem';
 
 import themeDecorator from '../themeDecorator';
 
@@ -41,20 +42,12 @@ export const Default: Story = {
 	args: {
 		title: 'Juice',
 		leftIcon: '!',
-		menuItems: [
-			{
-				label: 'Apple',
-				action: () => {
-					alert('apple juice!');
-				},
-			},
-			{
-				label: 'Orange',
-				action: () => {
-					alert('orange juice :(');
-				},
-			},
-		],
+		children: (
+			<>
+				<DropDownItem action={() => alert('apple juice!')}>Apple</DropDownItem>
+				<DropDownItem action={() => alert('orange juice :(')}>Orange</DropDownItem>
+			</>
+		),
 	},
 };
 
@@ -63,20 +56,12 @@ export const Disabled: Story = {
 		title: 'Juice',
 		leftIcon: '!',
 		disabled: true,
-		menuItems: [
-			{
-				label: 'Apple',
-				action: () => {
-					alert('apple juice!');
-				},
-			},
-			{
-				label: 'Orange',
-				action: () => {
-					alert('orange juice :(');
-				},
-			},
-		],
+		children: (
+			<>
+				<DropDownItem action={() => alert('apple juice!')}>Apple</DropDownItem>
+				<DropDownItem action={() => alert('orange juice :(')}>Orange</DropDownItem>
+			</>
+		),
 	},
 };
 

--- a/packages/ui/stories/dictionaryDecorator.tsx
+++ b/packages/ui/stories/dictionaryDecorator.tsx
@@ -145,7 +145,7 @@ const schemaMetaMap: Record<string, { submitter: string; domain: string }> = {
 	read_group: { submitter: 'Researcher', domain: 'Clinical' },
 };
 
-const customFilterDictionaryData: DictionaryTestData = [
+const filterDictionaryData: DictionaryTestData = [
 	{
 		...DictionarySample,
 		schemas: DictionarySample.schemas.map((schema) => ({
@@ -158,4 +158,4 @@ const customFilterDictionaryData: DictionaryTestData = [
 export const withMultipleDictionaries = withDictionaryContext(multipleDictionaryData);
 export const withSingleDictionary = withDictionaryContext(singleDictionaryData);
 export const withEmptyDictionaries = withDictionaryContext(emptyDictionaryData);
-export const withCustomFilterDictionary = withDictionaryContext(customFilterDictionaryData);
+export const withFilterDictionary = withDictionaryContext(filterDictionaryData);

--- a/packages/ui/stories/dictionaryDecorator.tsx
+++ b/packages/ui/stories/dictionaryDecorator.tsx
@@ -125,24 +125,24 @@ export const withErrorState = (): Decorator => {
 	);
 };
 
-const schemaMetaMap: Record<string, { category: string; tier: string }> = {
-	participant: { category: 'Clinical', tier: 'Required' },
-	sociodemographic: { category: 'Clinical', tier: 'Optional' },
-	demographic: { category: 'Clinical', tier: 'Required' },
-	diagnosis: { category: 'Clinical', tier: 'Required' },
-	treatment: { category: 'Clinical', tier: 'Optional' },
-	follow_up: { category: 'Clinical', tier: 'Optional' },
-	procedure: { category: 'Clinical', tier: 'Optional' },
-	medication: { category: 'Clinical', tier: 'Optional' },
-	radiation: { category: 'Clinical', tier: 'Optional' },
-	measurement: { category: 'Clinical', tier: 'Optional' },
-	phenotype: { category: 'Clinical', tier: 'Optional' },
-	comorbidity: { category: 'Clinical', tier: 'Optional' },
-	exposure: { category: 'Clinical', tier: 'Optional' },
-	specimen: { category: 'Biospecimen', tier: 'Required' },
-	sample: { category: 'Biospecimen', tier: 'Required' },
-	experiment: { category: 'Genomic', tier: 'Required' },
-	read_group: { category: 'Genomic', tier: 'Optional' },
+const schemaMetaMap: Record<string, { submitter: string; domain: string }> = {
+	participant: { submitter: 'Clinician', domain: 'Health' },
+	sociodemographic: { submitter: 'Clinician', domain: 'Health' },
+	demographic: { submitter: 'Clinician', domain: 'Health' },
+	diagnosis: { submitter: 'Clinician', domain: 'Clinical' },
+	treatment: { submitter: 'Clinician', domain: 'Clinical' },
+	follow_up: { submitter: 'Clinician', domain: 'Clinical' },
+	procedure: { submitter: 'Clinician', domain: 'Clinical' },
+	medication: { submitter: 'Laboratory', domain: 'Health' },
+	radiation: { submitter: 'Laboratory', domain: 'Health' },
+	measurement: { submitter: 'Laboratory', domain: 'Clinical' },
+	phenotype: { submitter: 'Researcher', domain: 'Clinical' },
+	comorbidity: { submitter: 'Researcher', domain: 'Clinical' },
+	exposure: { submitter: 'Researcher', domain: 'Clinical' },
+	specimen: { submitter: 'Laboratory', domain: 'Health' },
+	sample: { submitter: 'Laboratory', domain: 'Clinical' },
+	experiment: { submitter: 'Researcher', domain: 'Clinical' },
+	read_group: { submitter: 'Researcher', domain: 'Clinical' },
 };
 
 const customFilterDictionaryData: DictionaryTestData = [

--- a/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
+++ b/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
  *
  *  This program and the accompanying materials are made available under the terms of
  *  the GNU Affero General Public License v3.0. You should have received a copy of the

--- a/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
+++ b/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
@@ -95,12 +95,19 @@ export const LecternServer: Story = {
 	decorators: [withLecternUrl()],
 };
 
+export const WithSingleCustomFilter: Story = {
+	decorators: [withCustomFilterDictionary],
+	args: {
+		customFilterDropdowns: [{ label: 'Submitter', filterProperty: 'meta.submitter' }],
+	},
+};
+
 export const WithCustomFilterDropdowns: Story = {
 	decorators: [withCustomFilterDictionary],
 	args: {
 		customFilterDropdowns: [
-			{ label: 'Category', filterProperty: 'meta.category' },
-			{ label: 'Tier', filterProperty: 'meta.tier' },
+			{ label: 'Submitter', filterProperty: 'meta.submitter' },
+			{ label: 'Domain', filterProperty: 'meta.domain' },
 		],
 	},
 };

--- a/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
+++ b/packages/ui/stories/viewer-table/DictionaryViewerPage.stories.tsx
@@ -32,7 +32,7 @@ import {
 	withLecternUrl,
 	withMultipleDictionaries,
 	withSingleDictionary,
-	withCustomFilterDictionary,
+	withFilterDictionary,
 } from '../dictionaryDecorator';
 import themeDecorator from '../themeDecorator';
 
@@ -95,17 +95,17 @@ export const LecternServer: Story = {
 	decorators: [withLecternUrl()],
 };
 
-export const WithSingleCustomFilter: Story = {
-	decorators: [withCustomFilterDictionary],
+export const WithSingleFilter: Story = {
+	decorators: [withFilterDictionary],
 	args: {
-		customFilterDropdowns: [{ label: 'Submitter', filterProperty: 'meta.submitter' }],
+		filterDropdowns: [{ label: 'Submitter', filterProperty: 'meta.submitter' }],
 	},
 };
 
-export const WithCustomFilterDropdowns: Story = {
-	decorators: [withCustomFilterDictionary],
+export const WithFilterDropdowns: Story = {
+	decorators: [withFilterDictionary],
 	args: {
-		customFilterDropdowns: [
+		filterDropdowns: [
 			{ label: 'Submitter', filterProperty: 'meta.submitter' },
 			{ label: 'Domain', filterProperty: 'meta.domain' },
 		],

--- a/packages/ui/stories/viewer-table/Toolbar/AttributeFilterButton.stories.tsx
+++ b/packages/ui/stories/viewer-table/Toolbar/AttributeFilterButton.stories.tsx
@@ -22,25 +22,25 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import AttributeFilter from '../../../src/viewer-table/Toolbar/AttributeFilterDropdown';
+import AttributeFilterButton from '../../../src/viewer-table/Toolbar/AttributeFilterButton';
 
 import { withLoadingState, withMultipleDictionaries } from '../../dictionaryDecorator';
 import themeDecorator from '../../themeDecorator';
 
 const meta = {
-	component: AttributeFilter,
-	title: 'Viewer - Table/Toolbar/AttributeFilterDropdown',
+	component: AttributeFilterButton,
+	title: 'Viewer - Table/Toolbar/AttributeFilterButton',
 	tags: ['autodocs'],
 	decorators: [themeDecorator(), withMultipleDictionaries],
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'A dropdown component that allows users to filter dictionary fields by attributes such as required fields or all fields.',
+					'A button component that allows users to filter dictionary fields by attributes such as required fields or all fields.',
 			},
 		},
 	},
-} satisfies Meta<typeof AttributeFilter>;
+} satisfies Meta<typeof AttributeFilterButton>;
 
 export default meta;
 


### PR DESCRIPTION
Related to issue: #420, #421, #422 

## Summary

Replaced the single-select filter dropdowns with a multi-select checkbox dropdown, moved filter state into the shared context, and added an empty state UI with a reset button when no schemas match the selected filters. 

## Description of Changes

#420: Custom Filter State Management:
 - Moved custom filter selection state (customFilterSelections, toggleCustomFilter, resetCustomFilters) from the DictionaryTableViewer component into the DictionaryStateContext                                                                                            
  - Changed filter model from single-select (Record<string, string | undefined>) to multi-select (Record<string, string[]>) with OR logic within categories and AND logic across categories                                                                                                                   
  - Filter selections automatically reset when switching dictionaries                                                                                                                                                                                                                                  
  - Removed the 'All Fields' filter option 

 #421: Filters Toolbar Dropdown UI                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                
  - Replaced individual <Dropdown> components with a single unified filter dropdown using checkbox-based multi-select                                                                                                                                      
  - Added children and panelStyles props to the Dropdown component to support custom panel content
  - Refactored AttributeFilterDropdown to AttributeFilterButton and deleted the old component                                                                                                                                                                                                                      
  - Created FilterRows component with categorized checkbox lists and section headers (shown only when multiple categories exist)           

#422: Schema Filtering Logic & Empty State                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Updated getFilteredSchema to support multi-select filtering (OR within category, AND across categories)                                                                                                                                                                                                     
  - Added an empty state UI with CircleSlash icon, message, subtext, and a "Reset all filters" button with a new Refresh icon                                                                                                                                                                                 
  - Created and exported the Refresh and CircleSlash icon components                                                                                                                                                                                                                                            
  - Updated stories with new filter metadata (submitter/domain instead of category/tier) and added a WithSingleCustomFilter story                                                                         
 
## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
