### PR TITLE
#442: Custom Columns Prop (w/ Default Renderer & Dot Path Utility) 

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export {
 	type DictionaryStateProviderProps as DictionaryTableStateProviderProps,
 } from './dictionary-controller/DictionaryDataContext.js';
 
+export { getByDotPath } from './utils/getByDotPath.js';
 export { sortDictionariesByVersion } from './utils/sortDictionaries.js';
 
 // View Components
@@ -47,6 +48,12 @@ export {
 	type ExpandAllButtonProps,
 	TableOfContentsDropdown,
 	type TableOfContentsDropdownProps,
+
+	// Custom columns
+	type CustomColumnConfig,
+	type CustomColumnComponentProps,
+	MetaValueRenderer,
+	type MetaValueRendererProps,
 } from './viewer-table/index';
 
 export { default as Accordion, type AccordionProps } from './common/Accordion/index';

--- a/packages/ui/src/utils/getByDotPath.ts
+++ b/packages/ui/src/utils/getByDotPath.ts
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+export const getByDotPath = (obj: unknown, path: string): unknown =>
+	path
+		.split('.')
+		.reduce<unknown>(
+			(acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined),
+			obj,
+		);

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer.tsx
@@ -1,0 +1,144 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+import ReadMoreText from '../../../../common/ReadMoreText';
+import { type Theme, useThemeContext } from '../../../../theme/index';
+
+const URL_REGEX = /^https?:\/\/\S+$/;
+
+const isUrl = (value: string): boolean => URL_REGEX.test(value);
+
+const linkStyle = (theme: Theme) => css`
+	color: ${theme.colors.secondary};
+	text-decoration: none;
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
+const commaListStyle = css`
+	display: inline;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	& > li {
+		display: inline;
+	}
+
+	& > li + li::before {
+		content: ', ';
+	}
+`;
+
+const objectBlockStyle = css`
+	margin: 0;
+	padding: 0;
+`;
+
+const nestedObjectStyle = css`
+	padding-left: 12px;
+`;
+
+const objectEntryStyle = css`
+	margin: 0;
+`;
+
+const inheritTypographyStyle = css`
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+`;
+
+export type MetaValueRendererProps = {
+	value: unknown;
+};
+
+const isPlainValue = (value: unknown): boolean =>
+	value == null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+
+const renderValue = (value: unknown, theme: Theme): React.ReactNode => {
+	if (value == null) {
+		return null;
+	}
+
+	if (typeof value === 'string') {
+		if (isUrl(value)) {
+			return (
+				<a href={value} target="_blank" rel="noopener noreferrer" css={linkStyle(theme)}>
+					{value}
+				</a>
+			);
+		}
+		return <>{value}</>;
+	}
+
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return <>{String(value)}</>;
+	}
+
+	if (Array.isArray(value)) {
+		return (
+			<ul css={commaListStyle}>
+				{value.map((item, index) => (
+					<li key={index}>{renderValue(item, theme)}</li>
+				))}
+			</ul>
+		);
+	}
+
+	if (typeof value === 'object') {
+		return (
+			<div css={objectBlockStyle}>
+				{Object.entries(value).map(([key, val]) => (
+					<div key={key} css={objectEntryStyle}>
+						<strong>{key}:</strong>{' '}
+						{isPlainValue(val) || Array.isArray(val) ?
+							renderValue(val, theme)
+						:	<div css={nestedObjectStyle}>{renderValue(val, theme)}</div>}
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	return null;
+};
+
+const MetaValueRenderer = ({ value }: MetaValueRendererProps) => {
+	const theme = useThemeContext();
+
+	if (value == null) {
+		return null;
+	}
+
+	return (
+		<ReadMoreText maxLines={3} wrapperStyle={inheritTypographyStyle}>
+			{renderValue(value, theme)}
+		</ReadMoreText>
+	);
+};
+
+export default MetaValueRenderer;

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer.tsx
@@ -92,11 +92,11 @@ const renderValue = (value: unknown, theme: Theme): React.ReactNode => {
 				</a>
 			);
 		}
-		return <>{value}</>;
+		return <label>{value}</label>;
 	}
 
 	if (typeof value === 'number' || typeof value === 'boolean') {
-		return <>{String(value)}</>;
+		return <label>{String(value)}</label>;
 	}
 
 	if (Array.isArray(value)) {

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTable.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTable.tsx
@@ -19,6 +19,7 @@
 
 import { Schema } from '@overture-stack/lectern-dictionary';
 
+import type { CustomColumnConfig } from '../../customColumnTypes.js';
 import Table from '../Table';
 
 import { getSchemaBaseColumns } from './SchemaTableInit';
@@ -26,6 +27,7 @@ import { getSchemaBaseColumns } from './SchemaTableInit';
 export type SchemaTableProps = {
 	schema: Schema;
 	highlightedFieldName?: string | null;
+	customColumns?: CustomColumnConfig[];
 };
 
 /**
@@ -34,11 +36,11 @@ export type SchemaTableProps = {
  * @param {string | null} highlightedFieldName - Name of field to highlight (for anchor navigation)
  * @returns {JSX.Element} Table displaying schema fields with columns for Fields, Attribute, Data Type, and Allowed Values
  */
-const SchemaTable = ({ schema, highlightedFieldName }: SchemaTableProps) => {
+const SchemaTable = ({ schema, highlightedFieldName, customColumns }: SchemaTableProps) => {
 	return (
 		<Table
 			data={schema.fields}
-			columns={getSchemaBaseColumns(schema)}
+			columns={getSchemaBaseColumns(schema, customColumns)}
 			schemaName={schema.name}
 			highlightedFieldName={highlightedFieldName}
 		/>

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
@@ -35,7 +35,7 @@ import MetaValueRenderer from './Columns/MetaValueRenderer';
 const columnHelper = createColumnHelper<SchemaField>();
 
 const isDictionaryMetaValueOrMeta = (value: unknown): value is DictionaryMetaValue | DictionaryMeta => {
-	if (value == null) {
+	if (value === null) {
 		return false;
 	}
 
@@ -48,9 +48,9 @@ const isDictionaryMetaValueOrMeta = (value: unknown): value is DictionaryMetaVal
 	}
 
 	if (typeof value === 'object') {
-		return true;
+		return Object.values(value).every((v) => isDictionaryMetaValueOrMeta(v));
 	}
-	
+
 	return false;
 };
 
@@ -120,5 +120,3 @@ export const getSchemaBaseColumns = (schema: Schema, customColumns?: CustomColum
 		}),
 	),
 ];
-
-

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
@@ -21,22 +21,28 @@
 
 /** @jsxImportSource @emotion/react */
 
+import type { DictionaryMeta, DictionaryMetaValue } from '@overture-stack/lectern-dictionary';
 import { Schema, SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 import { CellContext, createColumnHelper, Row } from '@tanstack/react-table';
 
+import { getByDotPath } from '../../../utils/getByDotPath.js';
+import type { CustomColumnConfig } from '../../customColumnTypes.js';
 import { renderAllowedValuesColumn } from './Columns/AllowedValuesColumn/RenderAllowedValues';
 import { renderAttributesColumn } from './Columns/Attribute';
 import { renderDataTypeColumn } from './Columns/DataType';
 import { FieldsColumn } from './Columns/Fields';
+import MetaValueRenderer from './Columns/MetaValueRenderer';
 
 const columnHelper = createColumnHelper<SchemaField>();
 
 /**
  * Creates base column definitions for schema table display.
  * @param {Schema} schema - Dictionary schema containing field definitions and restrictions
- * @returns {ColumnDef<SchemaField, any>[]} Array of TanStack table column definitions for Fields, Attribute, Data Type, and Allowed Values
+ * @param {CustomColumnConfig[]} customColumns - Optional custom column configurations
+ * @returns {ColumnDef<SchemaField, any>[]} Array of TanStack table column definitions for Fields, Attribute, Data Type, Allowed Values, and any custom columns
  */
-export const getSchemaBaseColumns = (schema: Schema) => [
+
+export const getSchemaBaseColumns = (schema: Schema, customColumns?: CustomColumnConfig[]) => [
 	columnHelper.accessor('name', {
 		header: 'Fields',
 		cell: (field: CellContext<SchemaField, string>) => {
@@ -73,4 +79,26 @@ export const getSchemaBaseColumns = (schema: Schema) => [
 			return renderAllowedValuesColumn(fieldLevelRestrictions, schemaLevelRestrictions, schemaField, schema);
 		},
 	}),
+
+	...(customColumns ?? []).map((config, index) =>
+		columnHelper.display({
+			id: `custom-${index}-${config.columnHeader}`,
+			header: config.columnHeader,
+			cell: (cellContext: CellContext<SchemaField, unknown>) => {
+				const field = cellContext.row.original;
+				const metaPath = config.metaPath;
+				const value =
+					metaPath !== undefined ?
+						(getByDotPath(field, metaPath) as DictionaryMetaValue | DictionaryMeta | undefined)
+					:	undefined;
+
+				if (config.columnComponent) {
+					const Component = config.columnComponent;
+					return <Component field={field} metaPath={metaPath} value={value} />;
+				}
+
+				return <MetaValueRenderer value={value} />;
+			},
+		}),
+	),
 ];

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
@@ -24,9 +24,15 @@
 import type { DictionaryMeta, DictionaryMetaValue } from '@overture-stack/lectern-dictionary';
 import { Schema, SchemaField, SchemaFieldRestrictions } from '@overture-stack/lectern-dictionary';
 import { CellContext, createColumnHelper, Row } from '@tanstack/react-table';
-
 import { getByDotPath } from '../../../utils/getByDotPath.js';
 import type { CustomColumnConfig } from '../../customColumnTypes.js';
+import { renderAllowedValuesColumn } from './Columns/AllowedValuesColumn/RenderAllowedValues';
+import { renderAttributesColumn } from './Columns/Attribute';
+import { renderDataTypeColumn } from './Columns/DataType';
+import { FieldsColumn } from './Columns/Fields';
+import MetaValueRenderer from './Columns/MetaValueRenderer';
+
+const columnHelper = createColumnHelper<SchemaField>();
 
 const isDictionaryMetaValueOrMeta = (value: unknown): value is DictionaryMetaValue | DictionaryMeta => {
 	if (value == null) {
@@ -47,13 +53,6 @@ const isDictionaryMetaValueOrMeta = (value: unknown): value is DictionaryMetaVal
 	
 	return false;
 };
-import { renderAllowedValuesColumn } from './Columns/AllowedValuesColumn/RenderAllowedValues';
-import { renderAttributesColumn } from './Columns/Attribute';
-import { renderDataTypeColumn } from './Columns/DataType';
-import { FieldsColumn } from './Columns/Fields';
-import MetaValueRenderer from './Columns/MetaValueRenderer';
-
-const columnHelper = createColumnHelper<SchemaField>();
 
 /**
  * Creates base column definitions for schema table display.
@@ -121,3 +120,5 @@ export const getSchemaBaseColumns = (schema: Schema, customColumns?: CustomColum
 		}),
 	),
 ];
+
+

--- a/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
+++ b/packages/ui/src/viewer-table/DataTable/SchemaTable/SchemaTableInit.tsx
@@ -27,6 +27,26 @@ import { CellContext, createColumnHelper, Row } from '@tanstack/react-table';
 
 import { getByDotPath } from '../../../utils/getByDotPath.js';
 import type { CustomColumnConfig } from '../../customColumnTypes.js';
+
+const isDictionaryMetaValueOrMeta = (value: unknown): value is DictionaryMetaValue | DictionaryMeta => {
+	if (value == null) {
+		return false;
+	}
+
+	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+		return true;
+	}
+
+	if (Array.isArray(value)) {
+		return value.every((item) => typeof item === 'string' || typeof item === 'number');
+	}
+
+	if (typeof value === 'object') {
+		return true;
+	}
+	
+	return false;
+};
 import { renderAllowedValuesColumn } from './Columns/AllowedValuesColumn/RenderAllowedValues';
 import { renderAttributesColumn } from './Columns/Attribute';
 import { renderDataTypeColumn } from './Columns/DataType';
@@ -87,17 +107,16 @@ export const getSchemaBaseColumns = (schema: Schema, customColumns?: CustomColum
 			cell: (cellContext: CellContext<SchemaField, unknown>) => {
 				const field = cellContext.row.original;
 				const metaPath = config.metaPath;
-				const value =
-					metaPath !== undefined ?
-						(getByDotPath(field, metaPath) as DictionaryMetaValue | DictionaryMeta | undefined)
-					:	undefined;
+				const Component = config.columnComponent;
+				const value = metaPath !== undefined ? getByDotPath(field, metaPath) : undefined;
 
-				if (config.columnComponent) {
-					const Component = config.columnComponent;
-					return <Component field={field} metaPath={metaPath} value={value} />;
+				if (!Component) {
+					return <MetaValueRenderer value={value} />;
 				}
 
-				return <MetaValueRenderer value={value} />;
+				return (
+					<Component field={field} metaPath={metaPath} value={isDictionaryMetaValueOrMeta(value) ? value : undefined} />
+				);
 			},
 		}),
 	),

--- a/packages/ui/src/viewer-table/DataTable/TableRow.tsx
+++ b/packages/ui/src/viewer-table/DataTable/TableRow.tsx
@@ -48,10 +48,11 @@ const tdStyle = (theme: Theme, cellIndex: number, total: number) => css`
 	${theme.typography.paragraphSmall}
 	border-block: 2px solid ${theme.colors.border_light};
 	border-right: 2px solid ${theme.colors.border_light};
-	text-align: ${cellIndex === 1 || cellIndex === 2 ? 'center' : 'left'};
+	text-align: ${cellIndex === 0 || cellIndex === 3 ? 'left' : 'center'};
 	padding: 16px;
 	vertical-align: middle;
 	min-width: 150px;
+	max-width: 300px;
 
 	${cellIndex === 0 &&
 	`

--- a/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
+++ b/packages/ui/src/viewer-table/DictionaryTableViewer.tsx
@@ -27,14 +27,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Accordion from '../common/Accordion/index';
 import type { FilterCategory } from '../common/Dropdown/index';
-import Modal from '../common/Modal';
 import { ErrorModal } from '../common/Error/ErrorModal';
+import Modal from '../common/Modal';
 import {
 	type ActiveFilter,
 	useDictionaryDataContext,
 	useDictionaryStateContext,
 } from '../dictionary-controller/DictionaryDataContext';
+import { NoMarginParagraph } from '../theme/emotion/index';
 import { type Theme, useThemeContext } from '../theme/index';
+import { getByDotPath } from '../utils/getByDotPath.js';
 import { isFieldRequired } from '../utils/isFieldRequired';
 import { DiagramViewProvider, useDiagramViewContext } from './DiagramViewContext';
 import {
@@ -43,8 +45,8 @@ import {
 	RelationshipDiagramContent,
 	useActiveRelationship,
 } from './EntityRelationshipDiagram';
-import { NoMarginParagraph } from '../theme/emotion/index';
 
+import type { CustomColumnConfig } from './customColumnTypes.js';
 import SchemaTable from './DataTable/SchemaTable/index';
 import DictionaryHeader from './DictionaryHeader/DictionaryHeader';
 import DictionaryViewerLoadingPage from './DictionaryViewer/DictionaryViewerLoadingPage';
@@ -58,15 +60,8 @@ export type FilterDropdown = {
 
 export type DictionaryTableViewerProps = {
 	filterDropdowns?: FilterDropdown[];
+	customColumns?: CustomColumnConfig[];
 };
-
-const getByDotPath = (obj: unknown, path: string): unknown =>
-	path
-		.split('.')
-		.reduce<unknown>(
-			(acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined),
-			obj,
-		);
 
 type ParsedHashTarget = {
 	index: number;
@@ -244,7 +239,7 @@ const DiagramModal = () => {
 // TODO: produce a simplified version that accepts a dictionary and produces this same view,
 // so that there's no requirement for a Lectern server, etc. and without a Toolbar, or a simpler one.
 
-const DictionaryTableViewerContent = ({ filterDropdowns }: DictionaryTableViewerProps) => {
+const DictionaryTableViewerContent = ({ filterDropdowns, customColumns }: DictionaryTableViewerProps) => {
 	const theme = useThemeContext();
 	const { loading, errors } = useDictionaryDataContext();
 	const { filters, selectedDictionary, filterSelections, resetFilters } = useDictionaryStateContext();
@@ -365,6 +360,7 @@ const DictionaryTableViewerContent = ({ filterDropdowns }: DictionaryTableViewer
 						<SchemaTable
 							schema={filtered}
 							highlightedFieldName={highlightedField?.schemaName === schema.name ? highlightedField.fieldName : null}
+							customColumns={customColumns}
 						/>
 					),
 					schemaName: schema.name,
@@ -443,9 +439,9 @@ const DictionaryTableViewerContent = ({ filterDropdowns }: DictionaryTableViewer
 	);
 };
 
-export const DictionaryTableViewer = ({ filterDropdowns }: DictionaryTableViewerProps) => (
+export const DictionaryTableViewer = ({ filterDropdowns, customColumns }: DictionaryTableViewerProps) => (
 	<DiagramViewProvider>
-		<DictionaryTableViewerContent filterDropdowns={filterDropdowns} />
+		<DictionaryTableViewerContent filterDropdowns={filterDropdowns} customColumns={customColumns} />
 	</DiagramViewProvider>
 );
 

--- a/packages/ui/src/viewer-table/DictionaryViewerPage.tsx
+++ b/packages/ui/src/viewer-table/DictionaryViewerPage.tsx
@@ -20,24 +20,26 @@
 
 import { DictionaryLecternDataProvider, DictionaryStateProvider } from '../dictionary-controller/DictionaryDataContext';
 
-import DictionaryTableViewer from './DictionaryTableViewer';
+import type { CustomColumnConfig } from './customColumnTypes.js';
 import type { FilterDropdown } from './DictionaryTableViewer';
+import DictionaryTableViewer from './DictionaryTableViewer';
 
 export type DictionaryTableProps = {
 	lecternUrl: string;
 	dictionaryName: string;
 	filterDropdowns?: FilterDropdown[];
+	customColumns?: CustomColumnConfig[];
 };
 
 /**
  * DictionaryViewerPage component.
  * @param {DictionaryTableProps} props
  */
-const DictionaryViewerPage = ({ lecternUrl, dictionaryName, filterDropdowns }: DictionaryTableProps) => {
+const DictionaryViewerPage = ({ lecternUrl, dictionaryName, filterDropdowns, customColumns }: DictionaryTableProps) => {
 	return (
 		<DictionaryLecternDataProvider lecternUrl={lecternUrl} dictionaryName={dictionaryName}>
 			<DictionaryStateProvider>
-				<DictionaryTableViewer filterDropdowns={filterDropdowns} />
+				<DictionaryTableViewer filterDropdowns={filterDropdowns} customColumns={customColumns} />
 			</DictionaryStateProvider>
 		</DictionaryLecternDataProvider>
 	);

--- a/packages/ui/src/viewer-table/customColumnTypes.ts
+++ b/packages/ui/src/viewer-table/customColumnTypes.ts
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+import type { ComponentType } from 'react';
+import type { DictionaryMeta, DictionaryMetaValue, SchemaField } from '@overture-stack/lectern-dictionary';
+
+export type CustomColumnComponentProps = {
+	field: SchemaField;
+	metaPath: string | undefined;
+	value: DictionaryMetaValue | DictionaryMeta | undefined;
+};
+
+export type CustomColumnConfig = {
+	columnHeader: string;
+} & (
+	| { metaPath: string; columnComponent?: ComponentType<CustomColumnComponentProps> }
+	| { metaPath?: string; columnComponent: ComponentType<CustomColumnComponentProps> }
+);

--- a/packages/ui/src/viewer-table/customColumnTypes.ts
+++ b/packages/ui/src/viewer-table/customColumnTypes.ts
@@ -24,8 +24,8 @@ import type { DictionaryMeta, DictionaryMetaValue, SchemaField } from '@overture
 
 export type CustomColumnComponentProps = {
 	field: SchemaField;
-	metaPath: string | undefined;
-	value: DictionaryMetaValue | DictionaryMeta | undefined;
+	metaPath?: string;
+	value?: DictionaryMetaValue | DictionaryMeta;
 };
 
 export type CustomColumnConfig = {

--- a/packages/ui/src/viewer-table/index.ts
+++ b/packages/ui/src/viewer-table/index.ts
@@ -39,6 +39,8 @@ export {
 } from './Toolbar/index';
 
 // TODO: study which of the following are worth exporting at root, if any
+export * from './customColumnTypes';
 export * from './DictionaryTableViewer';
+export { default as MetaValueRenderer, type MetaValueRendererProps } from './DataTable/SchemaTable/Columns/MetaValueRenderer';
 export { type FilterCategory } from '../common/Dropdown/index';
 export * from './Loading';

--- a/packages/ui/stories/viewer-table/CustomColumns.stories.tsx
+++ b/packages/ui/stories/viewer-table/CustomColumns.stories.tsx
@@ -1,0 +1,233 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+import { type Dictionary, replaceReferences } from '@overture-stack/lectern-dictionary';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import type { CustomColumnComponentProps } from '../../src/viewer-table/customColumnTypes';
+import MetaValueRenderer from '../../src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer';
+import SchemaTable from '../../src/viewer-table/DataTable/SchemaTable/index';
+import { getByDotPath } from '../../src/utils/getByDotPath';
+import { useThemeContext } from '../../src/theme/index';
+import PCGL from '../fixtures/pcgl.json';
+import themeDecorator from '../themeDecorator';
+
+const pcglDictionary: Dictionary = replaceReferences(PCGL as Dictionary);
+
+// The participant schema has fields with rich meta (mappings, examples, etc.)
+const participantSchema = pcglDictionary.schemas[0];
+
+const meta = {
+	component: SchemaTable,
+	title: 'Viewer - Table/Custom Columns/Schema Table with Custom Columns',
+	tags: ['autodocs'],
+	decorators: [themeDecorator()],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Demonstrates the `customColumns` prop on SchemaTable. Custom columns can use a `metaPath` to display a meta value with the default MetaValueRenderer, a custom `columnComponent`, or both.',
+			},
+		},
+	},
+} satisfies Meta<typeof SchemaTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * No custom columns — the table renders with the four default columns only.
+ */
+export const NoCustomColumns: Story = {
+	args: {
+		schema: participantSchema,
+	},
+};
+
+/**
+ * A single custom column using `metaPath` to display the FHIR mapping for each field.
+ * Fields without a FHIR mapping show an empty cell.
+ */
+export const SingleMetaPathColumn: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'FHIR Mapping', metaPath: 'meta.mappings.FHIR' }],
+	},
+};
+
+/**
+ * Multiple metaPath columns showing different mapping standards side by side.
+ */
+export const MultipleMetaPathColumns: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [
+			{ columnHeader: 'FHIR', metaPath: 'meta.mappings.FHIR' },
+			{ columnHeader: 'ARGO', metaPath: 'meta.mappings.ARGO' },
+			{ columnHeader: 'Phenopacket', metaPath: 'meta.mappings.Phenopacket' },
+		],
+	},
+};
+
+/**
+ * A metaPath pointing to the entire `mappings` object, rendered as a key-value list
+ * by MetaValueRenderer.
+ */
+export const ObjectMetaPath: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'All Mappings', metaPath: 'meta.mappings' }],
+	},
+};
+
+/**
+ * A metaPath pointing to examples (an array of strings), rendered as a list.
+ */
+export const ArrayMetaPath: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'Examples', metaPath: 'meta.examples' }],
+	},
+};
+
+/**
+ * A custom column using `columnComponent` only. The component receives the full field
+ * but no metaPath or value, and renders whether a field has any mappings defined.
+ */
+const HasMappingsCell = ({ field }: CustomColumnComponentProps) => {
+	const theme = useThemeContext();
+	const mappings = field.meta?.mappings;
+	const hasMappings = mappings != null && typeof mappings === 'object' && Object.keys(mappings).length > 0;
+
+	return (
+		<span
+			css={css`
+				${theme.typography.data}
+				color: ${hasMappings ? theme.colors.accent_dark : theme.colors.grey_5};
+			`}
+		>
+			{hasMappings ? 'Yes' : 'No'}
+		</span>
+	);
+};
+
+export const ComponentOnlyColumn: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'Has Mappings', columnComponent: HasMappingsCell }],
+	},
+};
+
+/**
+ * A custom column using both `metaPath` and `columnComponent`. The component receives
+ * the resolved FHIR mapping value and renders it as a styled badge when present.
+ */
+const FhirBadgeCell = ({ value }: CustomColumnComponentProps) => {
+	const theme = useThemeContext();
+	if (value == null) return null;
+
+	return (
+		<span
+			css={css`
+				display: inline-flex;
+				align-items: center;
+				padding: 2px 8px;
+				border-radius: 20px;
+				border: 0.5px solid ${theme.colors.accent_dark};
+				background-color: rgba(255, 255, 255, 0.15);
+				color: ${theme.colors.accent_dark};
+				${theme.typography.data}
+			`}
+		>
+			{String(value)}
+		</span>
+	);
+};
+
+export const MetaPathWithComponent: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'FHIR Mapping', metaPath: 'meta.mappings.FHIR', columnComponent: FhirBadgeCell }],
+	},
+};
+
+/**
+ * Mixing different column types in a single configuration: a metaPath-only column,
+ * a component-only column, and a combined metaPath+component column.
+ */
+export const MixedColumnTypes: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [
+			{ columnHeader: 'ARGO Mapping', metaPath: 'meta.mappings.ARGO' },
+			{ columnHeader: 'Has Mappings', columnComponent: HasMappingsCell },
+			{
+				columnHeader: 'FHIR Badge',
+				metaPath: 'meta.mappings.FHIR',
+				columnComponent: FhirBadgeCell,
+			},
+		],
+	},
+};
+
+/**
+ * Demonstrates a component that uses `getByDotPath` and `MetaValueRenderer` internally
+ * to compose custom rendering with the standard display utilities.
+ */
+const MappingCountCell = ({ field }: CustomColumnComponentProps) => {
+	const theme = useThemeContext();
+	const mappings = getByDotPath(field, 'meta.mappings');
+	const count = mappings != null && typeof mappings === 'object' ? Object.keys(mappings).length : 0;
+
+	return (
+		<div>
+			<span
+				css={css`
+					${theme.typography.data}
+				`}
+			>
+				{count} mapping{count !== 1 ? 's' : ''}
+			</span>
+			{count > 0 && <MetaValueRenderer value={mappings} />}
+		</div>
+	);
+};
+
+export const ComponentUsingExportedUtilities: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'Mapping Details', columnComponent: MappingCountCell }],
+	},
+};
+
+/**
+ * A metaPath that doesn't match any data in the schema fields, producing empty cells
+ * for all rows.
+ */
+export const NonexistentMetaPath: Story = {
+	args: {
+		schema: participantSchema,
+		customColumns: [{ columnHeader: 'Missing Path', metaPath: 'meta.nonexistent.path' }],
+	},
+};

--- a/packages/ui/stories/viewer-table/CustomColumnsDictionaryPage.stories.tsx
+++ b/packages/ui/stories/viewer-table/CustomColumnsDictionaryPage.stories.tsx
@@ -1,0 +1,119 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DictionaryTableViewer } from '../../src/viewer-table/DictionaryTableViewer';
+import type { CustomColumnComponentProps } from '../../src/viewer-table/customColumnTypes';
+import { useThemeContext } from '../../src/theme/index';
+import { withSingleDictionary } from '../dictionaryDecorator';
+import themeDecorator from '../themeDecorator';
+
+const meta = {
+	component: DictionaryTableViewer,
+	title: 'Viewer - Table/Custom Columns/Dictionary Page with Custom Columns',
+	tags: ['autodocs'],
+	decorators: [themeDecorator()],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Full DictionaryTableViewer with custom columns. Shows how the `customColumns` prop integrates with the complete dictionary viewer including accordion, toolbar, and all schemas.',
+			},
+			story: {
+				inline: false,
+				iframeHeight: 600,
+			},
+		},
+	},
+} satisfies Meta<typeof DictionaryTableViewer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Dictionary page with a single FHIR mapping column added via metaPath.
+ */
+export const WithFhirColumn: Story = {
+	decorators: [withSingleDictionary],
+	args: {
+		customColumns: [{ columnHeader: 'FHIR Mapping', metaPath: 'meta.mappings.FHIR' }],
+	},
+};
+
+/**
+ * Dictionary page with multiple mapping columns.
+ */
+export const WithMultipleMappingColumns: Story = {
+	decorators: [withSingleDictionary],
+	args: {
+		customColumns: [
+			{ columnHeader: 'FHIR', metaPath: 'meta.mappings.FHIR' },
+			{ columnHeader: 'ARGO', metaPath: 'meta.mappings.ARGO' },
+		],
+	},
+};
+
+/**
+ * Dictionary page displaying all mappings as an object column.
+ */
+export const WithAllMappingsColumn: Story = {
+	decorators: [withSingleDictionary],
+	args: {
+		customColumns: [{ columnHeader: 'All Mappings', metaPath: 'meta.mappings' }],
+	},
+};
+
+const FhirBadge = ({ value }: CustomColumnComponentProps) => {
+	const theme = useThemeContext();
+	if (value == null) return null;
+	return (
+		<span
+			css={css`
+				display: inline-flex;
+				padding: 2px 8px;
+				border-radius: 20px;
+				border: 0.5px solid ${theme.colors.accent_dark};
+				color: ${theme.colors.accent_dark};
+				${theme.typography.data}
+			`}
+		>
+			{String(value)}
+		</span>
+	);
+};
+
+/**
+ * Dictionary page with a custom component column alongside a metaPath column.
+ */
+export const WithMixedColumns: Story = {
+	decorators: [withSingleDictionary],
+	args: {
+		customColumns: [
+			{ columnHeader: 'FHIR Badge', metaPath: 'meta.mappings.FHIR', columnComponent: FhirBadge },
+			{ columnHeader: 'ARGO Mapping', metaPath: 'meta.mappings.ARGO' },
+		],
+	},
+};

--- a/packages/ui/stories/viewer-table/MetaValueRenderer.stories.tsx
+++ b/packages/ui/stories/viewer-table/MetaValueRenderer.stories.tsx
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MetaValueRenderer from '../../src/viewer-table/DataTable/SchemaTable/Columns/MetaValueRenderer';
+import themeDecorator from '../themeDecorator';
+
+const meta = {
+	component: MetaValueRenderer,
+	title: 'Viewer - Table/Custom Columns/MetaValueRenderer',
+	tags: ['autodocs'],
+	decorators: [themeDecorator()],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Renders a meta value appropriately for display in a table cell. Handles strings, numbers, booleans, arrays, objects, URLs, and null/undefined values. Long values are truncated with the existing "show more" pattern.',
+			},
+		},
+	},
+} satisfies Meta<typeof MetaValueRenderer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StringValue: Story = {
+	args: { value: 'Patient.Identifier' },
+};
+
+export const UrlValue: Story = {
+	args: { value: 'https://hl7.org/fhir/R4/patient.html' },
+};
+
+export const NumberValue: Story = {
+	args: { value: 42 },
+};
+
+export const BooleanValue: Story = {
+	args: { value: true },
+};
+
+export const ArrayValue: Story = {
+	args: { value: ['90234', 42, true, 'https://hl7.org/fhir/R4/patient.html', 'AML-90'] },
+};
+
+export const SimpleObject: Story = {
+	args: {
+		value: {
+			FHIR: 'Patient.Identifier',
+			ARGO: 'submitter_participant_id',
+			CQDG: 'submitter_participant_id',
+		},
+	},
+};
+
+export const ObjectWithMixedValues: Story = {
+	args: {
+		value: {
+			optionA: 'value 1',
+			optionB: 987654321,
+			optionC: ['a', 'b', 'c'],
+			optionD: [123, 456, 789],
+		},
+	},
+};
+
+export const NestedObject: Story = {
+	args: {
+		value: {
+			value: 'value 1',
+			withNested: {
+				value: 123,
+				mostNested: {
+					value: ['a', 'b', 'c'],
+					moreNested: {
+						valuest: "important data, don't forget me!",
+					},
+				},
+			},
+		},
+	},
+};
+
+export const ObjectWithUrls: Story = {
+	args: {
+		value: {
+			FHIR: 'https://hl7.org/fhir/R4/patient.html',
+			Phenopacket: 'https://phenopacket-schema.readthedocs.io/',
+			localId: 'individual.id',
+		},
+	},
+};
+
+export const NullOrUndefinedValue: Story = {
+	args: { value: null },
+};


### PR DESCRIPTION
Related to issue: #442 

## Summary

Adds custom column support to the schema table, allowing developers to extend tables with additional data columns via field metadata, and provides a default MetaValueRenderer component for display handling.

## Description of Changes
  - Created CustomColumnConfig type requiring either a metaPath, a custom columnComponent, or both — with props (metaPath, value, field) passed to custom components                                                                                                                                            
  - Integrated customColumns prop through DictionaryViewerPage → DictionaryTableViewer → SchemaTable → SchemaTableInit, generating TanStack column  definitions for each config                                                                                                                             
 - Extracted getByDotPath utility to resolve dot-notation paths (e.g. meta.mappings.FHIR) against schema field objects
 - Created MetaValueRenderer component that accepts a single value of any type and renders it appropriately for table cells: strings as plain text (URLs as clickable links), numbers and booleans as their string representation, arrays as comma-separated lists, objects as compact key-value pairs with indented nesting, and null/undefined as empty cells                                                                                                     
  - Wraps content in ReadMoreText for truncation with the existing "show more" pattern                                                                  
  - Exported for use inside custom columnComponent implementations; used as the default renderer when only metaPath is provided         

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
